### PR TITLE
fix(cross-seed): remove qbittorrent authentication for cluster IPs

### DIFF
--- a/kubernetes/apps/default/cross-seed/app/externalsecret.yaml
+++ b/kubernetes/apps/default/cross-seed/app/externalsecret.yaml
@@ -34,7 +34,7 @@ spec:
             skipRecheck: true,
             radarr: ["http://radarr.default.svc.cluster.local/?apikey={{ .RADARR_API_KEY }}"],
             sonarr: ["http://sonarr.default.svc.cluster.local/?apikey={{ .SONARR_API_KEY }}"],
-            torrentClients: ["qbittorrent:http://admin:@qbittorrent.default.svc.cluster.local"],
+            torrentClients: ["qbittorrent:http://qbittorrent.default.svc.cluster.local"],
             torznab: fetchIndexers("http://prowlarr.default.svc.cluster.local", "{{.PROWLARR_API_KEY}}", "cross-seed"),
             useClientTorrents: true
           };


### PR DESCRIPTION
## Summary

Fixes cross-seed authentication issues with qBittorrent by removing username/password from the torrent client configuration.

## Changes

- Removed  authentication from the qBittorrent URL in cross-seed configuration
- This aligns with the qBittorrent auth bypass configuration for cluster IPs

## Issue

Cross-seed was failing to authenticate with qBittorrent with the error:
`qBittorrent login failed: Invalid username or password`

## Solution

Since authentication bypass is configured for cluster IPs in qBittorrent, cross-seed should connect without credentials when accessing via the cluster service URL.

## Testing

- [ ] Cross-seed pod should start without authentication errors
- [ ] Cross-seed should be able to communicate with qBittorrent API
- [ ] Flux should pick up and apply the configuration changes