### PR TITLE
feat: add gluetun port forwarding commands to qbittorrent

### DIFF
--- a/kubernetes/apps/default/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/default/qbittorrent/app/helmrelease.yaml
@@ -47,6 +47,8 @@ spec:
               PORT_FORWARD_ONLY: "on"
               VPN_INTERFACE: tun0
               UPDATER_PERIOD: 24h
+              VPN_PORT_FORWARDING_UP_COMMAND: '/bin/sh -c ''wget -O- --retry-connrefused --post-data "json={\"listen_port\":{{PORTS}}}" http://127.0.0.1:80/api/v2/app/setPreferences 2>&1'''
+              VPN_PORT_FORWARDING_DOWN_COMMAND: '/bin/sh -c ''wget -O- --retry-connrefused --post-data "json={\"listen_port\":65535}" http://127.0.0.1:80/api/v2/app/setPreferences 2>&1'''
             envFrom:
               - secretRef:
                   name: qbittorrent-secret


### PR DESCRIPTION
- Add VPN_PORT_FORWARDING_UP_COMMAND to automatically set forwarded port in qBittorrent
- Add VPN_PORT_FORWARDING_DOWN_COMMAND to set fallback port when forwarding fails
- Eliminates need for separate port sync container by using gluetun's built-in commands