### PR TITLE
fix: escape PORTS template in gluetun command

### DIFF
--- a/kubernetes/apps/default/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/default/qbittorrent/app/helmrelease.yaml
@@ -47,7 +47,7 @@ spec:
               PORT_FORWARD_ONLY: "on"
               VPN_INTERFACE: tun0
               UPDATER_PERIOD: 24h
-              VPN_PORT_FORWARDING_UP_COMMAND: '/bin/sh -c ''wget -O- --retry-connrefused --post-data "json={\"listen_port\":{{PORTS}}}" http://127.0.0.1:80/api/v2/app/setPreferences 2>&1'''
+              VPN_PORT_FORWARDING_UP_COMMAND: '/bin/sh -c ''wget -O- --retry-connrefused --post-data "json={\"listen_port\":{{ "{{PORTS}}" }}}" http://127.0.0.1:80/api/v2/app/setPreferences 2>&1'''
               VPN_PORT_FORWARDING_DOWN_COMMAND: '/bin/sh -c ''wget -O- --retry-connrefused --post-data "json={\"listen_port\":65535}" http://127.0.0.1:80/api/v2/app/setPreferences 2>&1'''
             envFrom:
               - secretRef:


### PR DESCRIPTION
- Use {{ "{{PORTS}}" }} to prevent Helm from trying to template the gluetun placeholder
- Allows gluetun to properly substitute the port number at runtime