### PR TITLE
feat(homeops-cli): make volsync snapshot-all wait by default

### DIFF
--- a/cmd/homeops-cli/cmd/volsync/volsync.go
+++ b/cmd/homeops-cli/cmd/volsync/volsync.go
@@ -213,7 +213,7 @@ func newSnapshotAllCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&namespace, "namespace", "", "Kubernetes namespace (if empty, searches all namespaces)")
-	cmd.Flags().BoolVar(&wait, "wait", false, "Wait for all snapshots to complete")
+	cmd.Flags().BoolVar(&wait, "wait", true, "Wait for all snapshots to complete")
 	cmd.Flags().DurationVar(&timeout, "timeout", 120*time.Minute, "Timeout for each snapshot completion")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show what would be snapshotted without actually triggering snapshots")
 


### PR DESCRIPTION
This change modifies the volsync snapshot-all command to wait for snapshot completion by default.\n\n**Changes:**\n- Changed the default value of the --wait flag from false to true\n- Ensures snapshots complete before reporting success\n- Users can still use --wait=false for async behavior\n\n**Motivation:**\nThe previous behavior of reporting success immediately after triggering snapshots was misleading, as it didn't confirm that the actual backup processes had completed.