### PR TITLE
fix: update mapstructure to v2.4.0 to address security vulnerability

### DIFF
--- a/cmd/homeops-cli/go.mod
+++ b/cmd/homeops-cli/go.mod
@@ -18,7 +18,7 @@ require (
 
 require (
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
+	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/cmd/homeops-cli/go.sum
+++ b/cmd/homeops-cli/go.sum
@@ -23,6 +23,8 @@ github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
+github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=


### PR DESCRIPTION
## Security Fix: mapstructure Vulnerability

This PR addresses a security vulnerability in the mapstructure dependency that could potentially leak sensitive information in logs when processing malformed data.

### Changes
- Updated  from  to 
- Resolves Dependabot alert GHSA-fv92-fjc5-jj9h

### Vulnerability Details
- **Affected versions**: mapstructure < v2.3.0
- **Issue**: Potential sensitive information leakage in logs when processing malformed data
- **Fix**: Update to v2.3.0 or later (we're updating to v2.4.0)

### Testing
- ✅ Build verification completed successfully
- ✅ All modules verified during build process
- ✅ No breaking changes detected

### Impact
This is a security-focused update with no functional changes to the application. The vulnerability was in an indirect dependency through viper, and this update ensures we're using the patched version.