### PR TITLE
fix: disable readOnlyRootFilesystem for karakeep containers

### DIFF
--- a/kubernetes/apps/default/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/default/karakeep/app/helmrelease.yaml
@@ -55,7 +55,7 @@ spec:
                 enabled: true
             securityContext:
               allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
+              readOnlyRootFilesystem: false
               capabilities: { drop: ["ALL"] }
             resources:
               requests:
@@ -83,7 +83,7 @@ spec:
               - --hide-scrollbars
             securityContext:
               allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
+              readOnlyRootFilesystem: false
               capabilities: { drop: ["ALL"] }
             resources:
               requests:


### PR DESCRIPTION
Security context was too restrictive, preventing necessary file system operations. Relaxing readOnlyRootFilesystem to false allows required functionality while maintaining other security constraints.