### PR TITLE
fix: remove runAsNonRoot from securityContext

### DIFF
--- a/kubernetes/apps/default/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/default/karakeep/app/helmrelease.yaml
@@ -128,7 +128,6 @@ spec:
                 memory: 4Gi
     defaultPodOptions:
       securityContext:
-        runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000


### PR DESCRIPTION
The runAsNonRoot setting is redundant since runAsUser is already set to a non-root user (1000). This simplifies the configuration while maintaining the same security posture.