### PR TITLE
fix(n8n): correct editor base url to use https protocol

### DIFF
--- a/kubernetes/apps/default/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/default/n8n/app/helmrelease.yaml
@@ -42,7 +42,7 @@ spec:
               N8N_PROTOCOL: "https"
               N8N_PORT: &port 8080
               N8N_HOST: &hostName "{{ .Release.Name }}.${SECRET_DOMAIN}"
-              N8N_EDITOR_BASE_URL: *hostName
+              N8N_EDITOR_BASE_URL: "https://{{ .Release.Name }}.${SECRET_DOMAIN}"
               WEBHOOK_URL: "https://{{ .Release.Name }}-webhook.${SECRET_DOMAIN}"
               N8N_LOG_LEVEL: info
               N8N_LOG_OUTPUT: console


### PR DESCRIPTION
The N8N_EDITOR_BASE_URL was using the hostname directly without the https protocol, which could cause issues with secure connections. This change ensures the editor base URL uses the correct https protocol.