### PR TITLE
fix(karakeep): upgrade meilisearch to v1.17.1 to resolve crashbackoff loop

### DIFF
--- a/kubernetes/apps/default/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/default/karakeep/app/helmrelease.yaml
@@ -109,7 +109,7 @@ spec:
           app:
             image:
               repository: docker.io/getmeili/meilisearch
-              tag: v1.16.0
+              tag: v1.17.1
             args:
               - /bin/meilisearch
               - --experimental-dumpless-upgrade


### PR DESCRIPTION
## Problem
The karakeep-meilisearch pod was stuck in a crashbackoff loop with the error:


## Solution
Upgraded the Meilisearch image tag from  to  in the HelmRelease configuration.

## Details
- The database was previously created with Meilisearch v1.17.1
- The current container was running v1.16.0
- Meilisearch doesn't support downgrading database versions
- This fix aligns the container version with the database version

## Testing
After this change is applied, the meilisearch pod should start successfully and the karakeep application should be fully functional.