### PR TITLE
Debug Vmagent Scrape Pool Configuration Issue

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/app/csi-metrics-service.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/csi-metrics-service.yaml
@@ -1,0 +1,35 @@
+---
+# Service for exposing CSI plugin liveness metrics
+apiVersion: v1
+kind: Service
+metadata:
+  name: csi-rbdplugin-metrics
+  namespace: rook-ceph
+  labels:
+    app: csi-metrics
+spec:
+  ports:
+    - name: csi-http-metrics
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: csi-rbdplugin
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: csi-cephfsplugin-metrics
+  namespace: rook-ceph
+  labels:
+    app: csi-metrics
+spec:
+  ports:
+    - name: csi-http-metrics
+      port: 9081
+      protocol: TCP
+      targetPort: 9081
+  selector:
+    app: csi-cephfsplugin
+  type: ClusterIP

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/csi-metrics-servicemonitor.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/csi-metrics-servicemonitor.yaml
@@ -1,0 +1,21 @@
+---
+# ServiceMonitor for scraping CSI plugin liveness metrics
+# This allows VictoriaMetrics (via Prometheus converter) to scrape CSI metrics
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: csi-metrics
+  namespace: rook-ceph
+  labels:
+    app.kubernetes.io/part-of: rook-ceph
+spec:
+  namespaceSelector:
+    matchNames:
+      - rook-ceph
+  selector:
+    matchLabels:
+      app: csi-metrics
+  endpoints:
+    - port: csi-http-metrics
+      path: /metrics
+      interval: 30s

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
@@ -14,8 +14,10 @@ spec:
     csi:
       cephFSKernelMountOptions: ms_mode=prefer-crc
       enableLiveness: true
+      # ServiceMonitor is created manually via csi-metrics-servicemonitor.yaml
+      # to work with VictoriaMetrics and ensure proper service/endpoint discovery
       serviceMonitor:
-        enabled: true
+        enabled: false
     image:
       repository: ghcr.io/rook/ceph
     monitoring:

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/kustomization.yaml
@@ -3,6 +3,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./csi-metrics-service.yaml
+  - ./csi-metrics-servicemonitor.yaml
   - ./externalsecret.yaml
   - ./grafanadashboards.yaml
   - ./helmrelease.yaml


### PR DESCRIPTION
Resolves the vmagent alert: ScrapePoolHasNoTargets for scrape_pool "serviceScrape/rook-ceph/csi-metrics/0"

Root cause analysis:
- Rook CSI liveness is enabled (csi.enableLiveness: true)
- Helm chart's csi.serviceMonitor.enabled creates a ServiceMonitor
- However, the ServiceMonitor had no targets because the required Service resources were not automatically created

Changes:
- Add csi-metrics-service.yaml with two services:
  - csi-rbdplugin-metrics (port 8080) for RBD plugin metrics
  - csi-cephfsplugin-metrics (port 9081) for CephFS plugin metrics
- Add csi-metrics-servicemonitor.yaml with ServiceMonitor that:
  - Selects services with label app: csi-metrics
  - Scrapes metrics from csi-http-metrics port
  - Uses 30s interval for metrics collection
- Disable helm chart's automatic ServiceMonitor creation (csi.serviceMonitor.enabled: false) to avoid conflicts
- Update kustomization.yaml to include new manifests

VictoriaMetrics will convert the ServiceMonitor to VMServiceScrape via its Prometheus converter and should now discover CSI endpoints.

Related documentation:
https://docs.victoriametrics.com/victoriametrics/vmagent/#debugging-scrape-targets https://rook.io/docs/rook/latest/Storage-Configuration/Monitoring/ceph-monitoring/