### PR TITLE
feat: Add Cloudflare Worker proxy for Kromgo cluster metrics

### DIFF
--- a/scripts/cloudflare-worker/kromgo-proxy/.gitignore
+++ b/scripts/cloudflare-worker/kromgo-proxy/.gitignore
@@ -1,0 +1,25 @@
+# Dependencies
+node_modules/
+package-lock.json
+
+# Wrangler
+.wrangler/
+wrangler.toml.local
+.dev.vars
+
+# Environment and secrets
+.env
+.env.local
+*.key
+*.pem
+
+# Editor
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db

--- a/scripts/cloudflare-worker/kromgo-proxy/QUICKSTART.md
+++ b/scripts/cloudflare-worker/kromgo-proxy/QUICKSTART.md
@@ -1,0 +1,167 @@
+# Kromgo Proxy - Quick Start Guide
+
+Get your kromgo metrics exposed publicly in under 5 minutes without revealing your domain!
+
+## Prerequisites
+
+- Cloudflare account (free tier is fine)
+- Your cluster must have kromgo running and accessible internally
+- Node.js and npm installed (for Wrangler CLI)
+
+## Step-by-Step Deployment
+
+### 1. Install Wrangler
+
+```bash
+npm install -g wrangler
+```
+
+### 2. Login to Cloudflare
+
+```bash
+wrangler login
+```
+
+A browser window will open - authenticate with your Cloudflare account.
+
+### 3. Navigate to the Worker Directory
+
+```bash
+cd scripts/cloudflare-worker/kromgo-proxy
+```
+
+### 4. Deploy the Worker
+
+```bash
+# Deploy to Cloudflare
+wrangler deploy
+```
+
+You'll see output like:
+
+```
+✨ Built successfully
+🌎 Uploading...
+✨ Uploaded kromgo-proxy (0.XX sec)
+✨ Published kromgo-proxy
+  https://kromgo-proxy.YOUR-USERNAME.workers.dev
+```
+
+**SAVE THIS URL!** You'll need it for badges.
+
+### 5. Set Your Secret Domain
+
+Your actual domain needs to be configured as a secret (encrypted, never visible):
+
+```bash
+wrangler secret put SECRET_DOMAIN
+```
+
+When prompted, enter your domain (e.g., `example.com`)
+
+### 6. Test the Deployment
+
+Test that a metric endpoint works:
+
+```bash
+# Replace YOUR-USERNAME with your actual Cloudflare username
+curl https://kromgo-proxy.YOUR-USERNAME.workers.dev/talos_version
+```
+
+Expected response:
+
+```json
+{
+  "schemaVersion": 1,
+  "label": "Talos",
+  "message": "1.8.3",
+  "color": "blue"
+}
+```
+
+### 7. Run the Security Test
+
+Verify no domain leakage:
+
+```bash
+./test-deployment.sh
+```
+
+Follow the prompts and ensure all tests pass.
+
+### 8. Add Badges to Your README
+
+1. Copy your worker URL: `kromgo-proxy.YOUR-USERNAME.workers.dev`
+2. URL-encode it:
+   - `:` becomes `%3A`
+   - `/` becomes `%2F`
+   - Result: `kromgo-proxy.YOUR-USERNAME.workers.dev` (no changes needed for this part)
+   - Full encoded URL: `https%3A%2F%2Fkromgo-proxy.YOUR-USERNAME.workers.dev`
+
+3. Use the badge examples from `badge-examples.md`
+
+Example badge:
+
+```markdown
+[![Talos](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo-proxy.YOUR-USERNAME.workers.dev%2Ftalos_version&style=for-the-badge&logo=talos&logoColor=white&color=blue&label=%20)](https://talos.dev)
+```
+
+## Troubleshooting
+
+### "Error: No account ID found"
+
+Run `wrangler login` again to re-authenticate.
+
+### Worker returns 503
+
+- Verify kromgo is running: `kubectl get pods -n observability -l app.kubernetes.io/name=kromgo`
+- Check if SECRET_DOMAIN is set correctly
+- View worker logs in Cloudflare dashboard: Workers & Pages → kromgo-proxy → Logs
+
+### Domain is leaking
+
+Run the test script and check the output:
+
+```bash
+./test-deployment.sh
+```
+
+If domain leaks are detected, ensure you're using the latest `src/index.js` code.
+
+### Badges not showing in README
+
+- Check that the URL is properly URL-encoded
+- Verify the metric endpoint returns data: `curl https://kromgo-proxy.YOUR-USERNAME.workers.dev/talos_version`
+- shields.io caches responses - wait a few minutes or add a cache-busting parameter
+
+## Security Checklist
+
+✅ **Worker deployed and returning metrics**
+✅ **SECRET_DOMAIN configured as encrypted secret**
+✅ **Test script passes all checks**
+✅ **No domain leakage detected**
+✅ **Only whitelisted metrics accessible**
+✅ **Invalid paths return 404**
+
+## Next Steps
+
+- Add badges to your README (see `badge-examples.md`)
+- Configure Cloudflare WAF rules for rate limiting (optional)
+- Enable Workers KV for advanced rate limiting (optional)
+- Monitor usage in Cloudflare dashboard
+
+## Cost
+
+**$0/month** with Cloudflare Workers free tier:
+- 100,000 requests/day
+- More than enough for README badges
+
+## Support
+
+Issues or questions? Check:
+- [README.md](./README.md) - Full documentation
+- [badge-examples.md](./badge-examples.md) - Badge customization
+- Cloudflare Worker logs in dashboard
+- Kromgo logs: `kubectl logs -n observability -l app.kubernetes.io/name=kromgo`
+
+Enjoy your shiny new cluster metrics badges! 🎉

--- a/scripts/cloudflare-worker/kromgo-proxy/QUICKSTART.md
+++ b/scripts/cloudflare-worker/kromgo-proxy/QUICKSTART.md
@@ -32,6 +32,20 @@ cd scripts/cloudflare-worker/kromgo-proxy
 
 ### 4. Deploy the Worker
 
+# Your actual domain needs to be configured as a secret (encrypted, never visible):
+
+```bash
+wrangler secret put SECRET_DOMAIN
+```
+# When prompted, enter your domain (e.g., `example.com`)
+```bash
+  wrangler secret put CF_CLIENT_ID
+```
+  # Paste the FULL Client ID with .access
+```bash
+   wrangler secret put CF_CLIENT_SECRET
+```
+  # Paste the FULL Client Secret
 ```bash
 # Deploy to Cloudflare
 wrangler deploy
@@ -49,17 +63,7 @@ You'll see output like:
 
 **SAVE THIS URL!** You'll need it for badges.
 
-### 5. Set Your Secret Domain
-
-Your actual domain needs to be configured as a secret (encrypted, never visible):
-
-```bash
-wrangler secret put SECRET_DOMAIN
-```
-
-When prompted, enter your domain (e.g., `example.com`)
-
-### 6. Test the Deployment
+### 5. Test the Deployment
 
 Test that a metric endpoint works:
 
@@ -79,7 +83,7 @@ Expected response:
 }
 ```
 
-### 7. Run the Security Test
+### 6. Run the Security Test
 
 Verify no domain leakage:
 
@@ -89,7 +93,7 @@ Verify no domain leakage:
 
 Follow the prompts and ensure all tests pass.
 
-### 8. Add Badges to Your README
+### 7. Add Badges to Your README
 
 1. Copy your worker URL: `kromgo-proxy.YOUR-USERNAME.workers.dev`
 2. URL-encode it:

--- a/scripts/cloudflare-worker/kromgo-proxy/README.md
+++ b/scripts/cloudflare-worker/kromgo-proxy/README.md
@@ -1,0 +1,216 @@
+# Kromgo Proxy - Cloudflare Worker
+
+This Cloudflare Worker acts as a secure proxy for your internal Kromgo metrics, allowing you to use shields.io badges in your README without exposing your actual domain name.
+
+## Features
+
+- ✅ **Domain Protection**: Your actual domain is never exposed in responses
+- ✅ **Security Whitelist**: Only allowed metrics can be accessed
+- ✅ **Error Sanitization**: No internal error details leaked
+- ✅ **Rate Limiting Ready**: Designed to add KV-based rate limiting
+- ✅ **Caching**: 5-minute cache to reduce load on internal service
+- ✅ **shields.io Compatible**: Returns proper endpoint badge format
+
+## Prerequisites
+
+- Cloudflare account (free tier works fine)
+- Node.js and npm installed
+- Access to your internal Kromgo instance
+
+## Installation
+
+### 1. Install Wrangler CLI
+
+```bash
+npm install -g wrangler
+```
+
+### 2. Login to Cloudflare
+
+```bash
+wrangler login
+```
+
+This will open a browser window to authenticate with Cloudflare.
+
+### 3. Deploy the Worker
+
+From this directory (`scripts/cloudflare-worker/kromgo-proxy`):
+
+```bash
+# Set your secret domain (the actual domain you want to hide)
+wrangler secret put SECRET_DOMAIN
+
+# When prompted, enter your domain (e.g., example.com)
+# This is stored encrypted and never visible in code
+
+# Deploy to Cloudflare
+wrangler deploy
+```
+
+### 4. Note Your Worker URL
+
+After deployment, Wrangler will output your worker URL:
+
+```
+https://kromgo-proxy.<your-cloudflare-username>.workers.dev
+```
+
+Save this URL - you'll use it in your README badges!
+
+## Testing
+
+Test that your worker is functioning correctly:
+
+```bash
+# Test a metric endpoint
+curl https://kromgo-proxy.<your-username>.workers.dev/talos_version
+
+# Expected response format (shields.io endpoint):
+{
+  "schemaVersion": 1,
+  "label": "Talos",
+  "message": "1.8.3",
+  "color": "blue"
+}
+```
+
+### Verify No Domain Leakage
+
+```bash
+# Check for your domain in all responses
+for metric in talos_version kubernetes_version flux_version; do
+  echo "Testing $metric..."
+  curl -v https://kromgo-proxy.<your-username>.workers.dev/$metric 2>&1 | grep -i "your-domain.com"
+done
+
+# Should return NOTHING - if it finds your domain, there's a leak!
+```
+
+## Usage in README Badges
+
+Use the shields.io dynamic endpoint badge format:
+
+```markdown
+[![Talos](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo-proxy.<your-username>.workers.dev%2Ftalos_version&style=for-the-badge&logo=talos&logoColor=white&color=blue&label=%20)](https://talos.dev)
+```
+
+**Note**: URL must be URL-encoded for shields.io. Use this format:
+- Replace `/` with `%2F`
+- Replace `:` with `%3A`
+
+Example: `https://kromgo-proxy.user.workers.dev/talos_version` becomes:
+```
+https%3A%2F%2Fkromgo-proxy.user.workers.dev%2Ftalos_version
+```
+
+## Available Metrics
+
+The worker exposes these metrics (defined in your kromgo config):
+
+- `talos_version` - Talos Linux version
+- `kubernetes_version` - Kubernetes version
+- `flux_version` - Flux version
+- `cluster_node_count` - Number of nodes
+- `cluster_pod_count` - Number of running pods
+- `cluster_cpu_usage` - CPU usage percentage
+- `cluster_memory_usage` - Memory usage percentage
+- `cluster_age_days` - Cluster age in days
+- `cluster_uptime_days` - Cluster uptime in days
+- `cluster_alert_count` - Active alert count
+
+Any other paths will return a 404 error.
+
+## Security Considerations
+
+### What's Protected
+
+✅ **Your domain name**: Never appears in responses or headers
+✅ **Internal URLs**: Error messages are generic
+✅ **Path traversal**: Only whitelisted metrics allowed
+✅ **Method restriction**: Only GET requests accepted
+
+### What's Public
+
+⚠️ **Metric values**: Anyone can see your cluster metrics (CPU, memory, versions)
+⚠️ **Worker URL**: Your Cloudflare username is in the worker URL
+
+This is expected - the goal is to share metrics publicly while hiding your domain.
+
+### Recommended Additional Security
+
+1. **Enable Rate Limiting** (optional, requires Workers KV):
+
+```bash
+# Create KV namespace
+wrangler kv:namespace create "RATE_LIMIT"
+
+# Update wrangler.toml with the namespace ID
+# Then uncomment the rate limiting code in src/index.js
+```
+
+2. **Cloudflare WAF Rules** (in Cloudflare Dashboard):
+
+Go to Workers & Pages → kromgo-proxy → Settings → Add WAF rules:
+
+```
+# Rate limit: 100 requests per minute per IP
+rate.requests.count > 100
+
+# Block known bad bots
+http.user_agent contains "scanner"
+```
+
+## Updating the Worker
+
+When you modify kromgo metrics or need to update the worker:
+
+```bash
+# Make changes to src/index.js
+# Then redeploy
+wrangler deploy
+```
+
+Changes take effect immediately (within seconds).
+
+## Troubleshooting
+
+### Worker returns 503 "unavailable"
+
+- Check that your kromgo service is running: `kubectl get pods -n observability`
+- Verify SECRET_DOMAIN is set correctly: Re-run `wrangler secret put SECRET_DOMAIN`
+- Check Cloudflare Worker logs in the dashboard
+
+### Domain is leaking in responses
+
+- Run the domain leakage test above
+- Check that you're using the latest version of `src/index.js`
+- Ensure no custom headers are being forwarded
+
+### Badges not updating
+
+- Shields.io caches responses - add `?dummy=123` to URLs to bypass cache
+- Check worker cache (5 min default) - wait and retry
+- Verify metric name matches exactly (case-sensitive)
+
+## Cost
+
+Cloudflare Workers free tier includes:
+- **100,000 requests per day**
+- **10ms CPU time per request**
+
+For README badges, you'll use maybe 1000-2000 requests/day (assuming moderate traffic).
+
+**Cost: $0/month** ✨
+
+## Support
+
+If you encounter issues:
+
+1. Check Cloudflare Worker logs in the dashboard
+2. Review kromgo logs: `kubectl logs -n observability -l app.kubernetes.io/name=kromgo`
+3. Test kromgo directly (from inside cluster): `kubectl run -it --rm debug --image=curlimages/curl --restart=Never -- curl kromgo.observability.svc.cluster.local/talos_version`
+
+## License
+
+MIT - Feel free to use and modify for your own homelab!

--- a/scripts/cloudflare-worker/kromgo-proxy/README.md
+++ b/scripts/cloudflare-worker/kromgo-proxy/README.md
@@ -38,12 +38,18 @@ This will open a browser window to authenticate with Cloudflare.
 From this directory (`scripts/cloudflare-worker/kromgo-proxy`):
 
 ```bash
-# Set your secret domain (the actual domain you want to hide)
 wrangler secret put SECRET_DOMAIN
-
-# When prompted, enter your domain (e.g., example.com)
-# This is stored encrypted and never visible in code
-
+```
+# When prompted, enter your domain (e.g., `example.com`)
+```bash
+  wrangler secret put CF_CLIENT_ID
+```
+  # Paste the FULL Client ID with .access
+```bash
+   wrangler secret put CF_CLIENT_SECRET
+```
+  # Paste the FULL Client Secret
+```bash
 # Deploy to Cloudflare
 wrangler deploy
 ```

--- a/scripts/cloudflare-worker/kromgo-proxy/badge-examples.md
+++ b/scripts/cloudflare-worker/kromgo-proxy/badge-examples.md
@@ -1,0 +1,164 @@
+# README Badge Examples
+
+After deploying your Cloudflare Worker, use these badge examples in your README.md.
+
+**Replace `<WORKER_URL>` with your actual worker URL** (e.g., `kromgo-proxy.username.workers.dev`)
+
+## Top Row - Large Badges (for-the-badge style)
+
+```markdown
+<div align="center">
+
+[![Discord](https://img.shields.io/discord/673534664354430999?style=for-the-badge&label&logo=discord&logoColor=white&color=blue)](https://discord.gg/home-operations)&nbsp;&nbsp;
+[![Talos](https://img.shields.io/endpoint?url=https%3A%2F%2F<WORKER_URL>%2Ftalos_version&style=for-the-badge&logo=talos&logoColor=white&color=blue&label=%20)](https://talos.dev)&nbsp;&nbsp;
+[![Kubernetes](https://img.shields.io/endpoint?url=https%3A%2F%2F<WORKER_URL>%2Fkubernetes_version&style=for-the-badge&logo=kubernetes&logoColor=white&color=blue&label=%20)](https://kubernetes.io)&nbsp;&nbsp;
+[![Flux](https://img.shields.io/endpoint?url=https%3A%2F%2F<WORKER_URL>%2Fflux_version&style=for-the-badge&logo=flux&logoColor=white&color=blue&label=%20)](https://fluxcd.io)&nbsp;&nbsp;
+[![Renovate](https://img.shields.io/github/actions/workflow/status/GizmoTickler/home-ops/renovate.yaml?branch=main&label=&logo=renovatebot&style=for-the-badge&color=blue)](https://github.com/GizmoTickler/home-ops/actions/workflows/renovate.yaml)
+
+</div>
+```
+
+## Bottom Row - Small Badges (flat-square style)
+
+```markdown
+<div align="center">
+
+[![Age-Days](https://img.shields.io/endpoint?url=https%3A%2F%2F<WORKER_URL>%2Fcluster_age_days&style=flat-square&label=Age)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
+[![Uptime-Days](https://img.shields.io/endpoint?url=https%3A%2F%2F<WORKER_URL>%2Fcluster_uptime_days&style=flat-square&label=Uptime)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
+[![Node-Count](https://img.shields.io/endpoint?url=https%3A%2F%2F<WORKER_URL>%2Fcluster_node_count&style=flat-square&label=Nodes)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
+[![Pod-Count](https://img.shields.io/endpoint?url=https%3A%2F%2F<WORKER_URL>%2Fcluster_pod_count&style=flat-square&label=Pods)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
+[![CPU-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2F<WORKER_URL>%2Fcluster_cpu_usage&style=flat-square&label=CPU)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
+[![Memory-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2F<WORKER_URL>%2Fcluster_memory_usage&style=flat-square&label=Memory)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
+[![Alerts](https://img.shields.io/endpoint?url=https%3A%2F%2F<WORKER_URL>%2Fcluster_alert_count&style=flat-square&label=Alerts)](https://github.com/kashalls/kromgo)
+
+</div>
+```
+
+## URL Encoding Reference
+
+Shields.io requires URLs to be URL-encoded. Here's the pattern:
+
+**Original URL:**
+```
+https://kromgo-proxy.username.workers.dev/talos_version
+```
+
+**URL-encoded version:**
+```
+https%3A%2F%2Fkromgo-proxy.username.workers.dev%2Ftalos_version
+```
+
+**Encoding rules:**
+- `:` → `%3A`
+- `/` → `%2F`
+- `.` → `.` (no encoding needed)
+- `-` → `-` (no encoding needed)
+
+## Quick URL Encoder
+
+Use this bash command to encode your worker URL:
+
+```bash
+WORKER_URL="kromgo-proxy.username.workers.dev"
+echo "https%3A%2F%2F${WORKER_URL}%2Ftalos_version"
+```
+
+Or use an online tool: https://www.urlencoder.org/
+
+## Testing Your Badges
+
+Before adding to README, test each badge URL:
+
+```bash
+# Test that kromgo returns data
+curl https://kromgo-proxy.username.workers.dev/talos_version
+
+# Test shields.io rendering (paste in browser)
+https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo-proxy.username.workers.dev%2Ftalos_version
+```
+
+## Badge Customization
+
+### Colors
+
+Change the `color` parameter:
+- `blue` - Default blue
+- `green` - Success/healthy
+- `red` - Error/alert
+- `orange` - Warning
+- `yellow` - Caution
+- `brightgreen` - Very positive
+- `lightgrey` - Neutral
+
+### Styles
+
+Change the `style` parameter:
+- `flat-square` - Flat with square corners (compact)
+- `for-the-badge` - Large bold badges
+- `flat` - Flat with rounded corners
+- `plastic` - Shiny plastic look
+- `social` - Social media style
+
+### Logos
+
+Add logo with `logo` parameter:
+- `talos` - Talos Linux
+- `kubernetes` - Kubernetes
+- `flux` - Flux
+- `prometheus` - Prometheus
+- `grafana` - Grafana
+- Full list: https://simpleicons.org/
+
+## Example Variations
+
+### With custom color based on metric:
+
+```markdown
+[![CPU](https://img.shields.io/endpoint?url=https%3A%2F%2F<WORKER_URL>%2Fcluster_cpu_usage&style=flat-square&label=CPU)](https://github.com/kashalls/kromgo)
+```
+
+The color will be automatically set by kromgo based on your config.yaml color rules.
+
+### With Prometheus logo:
+
+```markdown
+[![Alerts](https://img.shields.io/endpoint?url=https%3A%2F%2F<WORKER_URL>%2Fcluster_alert_count&style=for-the-badge&logo=prometheus&logoColor=white&label=Alerts)](https://github.com/kashalls/kromgo)
+```
+
+## Full Example for README.md
+
+Here's the complete section you can add after deploying:
+
+```markdown
+<div align="center">
+<img src="https://github.com/user-attachments/assets/4a3122ae-706d-4e21-8130-f5a8c9483710" align="center" width="195px" height="195px"/>
+
+### 🚀 Home Operations Repository 🚧
+
+_Kubernetes cluster running on ESXi VMs with TrueNAS storage, managed with Talos, Flux, and GitOps_ 🤖
+
+</div>
+
+<div align="center">
+
+[![Talos](https://img.shields.io/endpoint?url=https%3A%2F%2F<WORKER_URL>%2Ftalos_version&style=for-the-badge&logo=talos&logoColor=white&color=blue&label=%20)](https://www.talos.dev/)&nbsp;&nbsp;
+[![Kubernetes](https://img.shields.io/endpoint?url=https%3A%2F%2F<WORKER_URL>%2Fkubernetes_version&style=for-the-badge&logo=kubernetes&logoColor=white&color=blue&label=%20)](https://kubernetes.io/)&nbsp;&nbsp;
+[![Flux](https://img.shields.io/endpoint?url=https%3A%2F%2F<WORKER_URL>%2Fflux_version&style=for-the-badge&logo=flux&logoColor=white&color=blue&label=%20)](https://fluxcd.io/)&nbsp;&nbsp;
+[![Renovate](https://img.shields.io/badge/Renovate-enabled-blue?style=for-the-badge&logo=renovatebot&logoColor=white)](https://renovatebot.com/)
+
+</div>
+
+<div align="center">
+
+[![Age-Days](https://img.shields.io/endpoint?url=https%3A%2F%2F<WORKER_URL>%2Fcluster_age_days&style=flat-square&label=Age)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
+[![Uptime-Days](https://img.shields.io/endpoint?url=https%3A%2F%2F<WORKER_URL>%2Fcluster_uptime_days&style=flat-square&label=Uptime)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
+[![Node-Count](https://img.shields.io/endpoint?url=https%3A%2F%2F<WORKER_URL>%2Fcluster_node_count&style=flat-square&label=Nodes)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
+[![Pod-Count](https://img.shields.io/endpoint?url=https%3A%2F%2F<WORKER_URL>%2Fcluster_pod_count&style=flat-square&label=Pods)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
+[![CPU-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2F<WORKER_URL>%2Fcluster_cpu_usage&style=flat-square&label=CPU)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
+[![Memory-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2F<WORKER_URL>%2Fcluster_memory_usage&style=flat-square&label=Memory)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
+[![Alerts](https://img.shields.io/endpoint?url=https%3A%2F%2F<WORKER_URL>%2Fcluster_alert_count&style=flat-square&label=Alerts)](https://github.com/kashalls/kromgo)
+
+</div>
+```
+
+Remember to replace `<WORKER_URL>` with your actual worker URL!

--- a/scripts/cloudflare-worker/kromgo-proxy/package.json
+++ b/scripts/cloudflare-worker/kromgo-proxy/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "kromgo-proxy",
+  "version": "1.0.0",
+  "description": "Cloudflare Worker proxy for Kromgo metrics without domain exposure",
+  "main": "src/index.js",
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev",
+    "test": "node test.js"
+  },
+  "keywords": [
+    "cloudflare",
+    "worker",
+    "kromgo",
+    "kubernetes",
+    "metrics",
+    "shields.io"
+  ],
+  "author": "GizmoTickler",
+  "license": "MIT",
+  "devDependencies": {
+    "wrangler": "^3.0.0"
+  }
+}

--- a/scripts/cloudflare-worker/kromgo-proxy/src/index.js
+++ b/scripts/cloudflare-worker/kromgo-proxy/src/index.js
@@ -1,0 +1,129 @@
+/**
+ * Cloudflare Worker: Kromgo Metrics Proxy
+ *
+ * Securely exposes Kubernetes cluster metrics from internal Kromgo instance
+ * without revealing the actual domain. Metrics are used with shields.io badges.
+ *
+ * Security features:
+ * - Whitelist of allowed metrics only (no path traversal)
+ * - Strips all upstream headers (prevents domain leakage)
+ * - Generic error messages (no internal details exposed)
+ * - CORS headers for shields.io compatibility
+ * - 5-minute cache to reduce load
+ */
+
+export default {
+  async fetch(request, env) {
+    // Handle CORS preflight requests
+    if (request.method === 'OPTIONS') {
+      return new Response(null, {
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'GET',
+          'Access-Control-Max-Age': '86400',
+        }
+      });
+    }
+
+    // Only allow GET requests
+    if (request.method !== 'GET') {
+      return new Response('Method not allowed', { status: 405 });
+    }
+
+    const url = new URL(request.url);
+
+    // Whitelist of allowed metric endpoints (from config.yaml)
+    const allowedMetrics = [
+      'talos_version',
+      'kubernetes_version',
+      'flux_version',
+      'cluster_node_count',
+      'cluster_pod_count',
+      'cluster_cpu_usage',
+      'cluster_memory_usage',
+      'cluster_age_days',
+      'cluster_uptime_days',
+      'cluster_alert_count'
+    ];
+
+    // Extract metric name from path (remove leading /)
+    const metricName = url.pathname.substring(1);
+
+    // Return 404 for any non-whitelisted metrics
+    if (!metricName || !allowedMetrics.includes(metricName)) {
+      return new Response(JSON.stringify({
+        schemaVersion: 1,
+        label: 'error',
+        message: 'not found',
+        color: 'red'
+      }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    try {
+      // Fetch from internal kromgo instance
+      // SECRET_DOMAIN is set as a Cloudflare Worker secret (never exposed)
+      const kromgoUrl = `https://kromgo.${env.SECRET_DOMAIN}/${metricName}`;
+
+      const response = await fetch(kromgoUrl, {
+        headers: {
+          'User-Agent': 'CloudflareWorker-KromgoProxy/1.0',
+        },
+        // Timeout after 5 seconds
+        signal: AbortSignal.timeout(5000)
+      });
+
+      if (!response.ok) {
+        // Return a valid shields.io endpoint format on error
+        return new Response(JSON.stringify({
+          schemaVersion: 1,
+          label: 'error',
+          message: 'unavailable',
+          color: 'lightgrey'
+        }), {
+          status: 503,
+          headers: {
+            'Content-Type': 'application/json',
+            'Cache-Control': 'no-cache'
+          }
+        });
+      }
+
+      // Parse the kromgo response
+      const data = await response.json();
+
+      // Return clean response with ONLY the data
+      // Strip all headers from upstream to prevent domain leakage
+      return new Response(JSON.stringify(data), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+          'Cache-Control': 'public, max-age=300', // Cache for 5 minutes
+          'X-Robots-Tag': 'noindex', // Don't index these endpoints
+          'Referrer-Policy': 'no-referrer', // Don't leak referrer
+        }
+      });
+
+    } catch (error) {
+      // Log error to Cloudflare dashboard (not visible to users)
+      console.error('Kromgo fetch failed:', error.message);
+
+      // Return generic error in shields.io format
+      return new Response(JSON.stringify({
+        schemaVersion: 1,
+        label: 'error',
+        message: 'timeout',
+        color: 'lightgrey'
+      }), {
+        status: 503,
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-cache'
+        }
+      });
+    }
+  }
+}

--- a/scripts/cloudflare-worker/kromgo-proxy/src/index.js
+++ b/scripts/cloudflare-worker/kromgo-proxy/src/index.js
@@ -1,129 +1,140 @@
-/**
- * Cloudflare Worker: Kromgo Metrics Proxy
- *
- * Securely exposes Kubernetes cluster metrics from internal Kromgo instance
- * without revealing the actual domain. Metrics are used with shields.io badges.
- *
- * Security features:
- * - Whitelist of allowed metrics only (no path traversal)
- * - Strips all upstream headers (prevents domain leakage)
- * - Generic error messages (no internal details exposed)
- * - CORS headers for shields.io compatibility
- * - 5-minute cache to reduce load
- */
-
-export default {
+// src/index.js
+var index_default = {
   async fetch(request, env) {
-    // Handle CORS preflight requests
-    if (request.method === 'OPTIONS') {
+    // Handle CORS preflight
+    if (request.method === "OPTIONS") {
       return new Response(null, {
         headers: {
-          'Access-Control-Allow-Origin': '*',
-          'Access-Control-Allow-Methods': 'GET',
-          'Access-Control-Max-Age': '86400',
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Methods": "GET",
+          "Access-Control-Max-Age": "86400"
         }
       });
     }
 
     // Only allow GET requests
-    if (request.method !== 'GET') {
-      return new Response('Method not allowed', { status: 405 });
+    if (request.method !== "GET") {
+      return new Response("Method not allowed", { status: 405 });
+    }
+
+    // Validate environment variables
+    if (!env.CF_CLIENT_ID || !env.CF_CLIENT_SECRET || !env.SECRET_DOMAIN) {
+      return new Response(JSON.stringify({
+        schemaVersion: 1,
+        label: "error",
+        message: "misconfigured",
+        color: "critical"
+      }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" }
+      });
     }
 
     const url = new URL(request.url);
 
-    // Whitelist of allowed metric endpoints (from config.yaml)
+    // Whitelist of allowed metrics
     const allowedMetrics = [
-      'talos_version',
-      'kubernetes_version',
-      'flux_version',
-      'cluster_node_count',
-      'cluster_pod_count',
-      'cluster_cpu_usage',
-      'cluster_memory_usage',
-      'cluster_age_days',
-      'cluster_uptime_days',
-      'cluster_alert_count'
+      "talos_version",
+      "kubernetes_version",
+      "flux_version",
+      "cluster_node_count",
+      "cluster_pod_count",
+      "cluster_cpu_usage",
+      "cluster_memory_usage",
+      "cluster_age_days",
+      "cluster_uptime_days",
+      "cluster_alert_count"
     ];
 
-    // Extract metric name from path (remove leading /)
     const metricName = url.pathname.substring(1);
 
-    // Return 404 for any non-whitelisted metrics
+    // Validate metric name
     if (!metricName || !allowedMetrics.includes(metricName)) {
       return new Response(JSON.stringify({
         schemaVersion: 1,
-        label: 'error',
-        message: 'not found',
-        color: 'red'
+        label: "error",
+        message: "not found",
+        color: "red"
       }), {
         status: 404,
-        headers: { 'Content-Type': 'application/json' }
+        headers: { "Content-Type": "application/json" }
       });
     }
 
     try {
-      // Fetch from internal kromgo instance
-      // SECRET_DOMAIN is set as a Cloudflare Worker secret (never exposed)
       const kromgoUrl = `https://kromgo.${env.SECRET_DOMAIN}/${metricName}`;
 
       const response = await fetch(kromgoUrl, {
         headers: {
-          'User-Agent': 'CloudflareWorker-KromgoProxy/1.0',
+          "CF-Access-Client-Id": env.CF_CLIENT_ID,
+          "CF-Access-Client-Secret": env.CF_CLIENT_SECRET
         },
-        // Timeout after 5 seconds
         signal: AbortSignal.timeout(5000)
       });
 
-      if (!response.ok) {
-        // Return a valid shields.io endpoint format on error
+      const contentType = response.headers.get("content-type") || "";
+
+      // Detect auth failure (HTML response instead of JSON)
+      if (contentType.includes("text/html")) {
         return new Response(JSON.stringify({
           schemaVersion: 1,
-          label: 'error',
-          message: 'unavailable',
-          color: 'lightgrey'
+          label: "kromgo",
+          message: "auth failed",
+          color: "critical"
         }), {
           status: 503,
           headers: {
-            'Content-Type': 'application/json',
-            'Cache-Control': 'no-cache'
+            "Content-Type": "application/json",
+            "Cache-Control": "no-cache"
           }
         });
       }
 
-      // Parse the kromgo response
+      if (!response.ok) {
+        return new Response(JSON.stringify({
+          schemaVersion: 1,
+          label: "error",
+          message: "unavailable",
+          color: "lightgrey"
+        }), {
+          status: 503,
+          headers: {
+            "Content-Type": "application/json",
+            "Cache-Control": "no-cache"
+          }
+        });
+      }
+
       const data = await response.json();
 
-      // Return clean response with ONLY the data
-      // Strip all headers from upstream to prevent domain leakage
       return new Response(JSON.stringify(data), {
         status: 200,
         headers: {
-          'Content-Type': 'application/json',
-          'Access-Control-Allow-Origin': '*',
-          'Cache-Control': 'public, max-age=300', // Cache for 5 minutes
-          'X-Robots-Tag': 'noindex', // Don't index these endpoints
-          'Referrer-Policy': 'no-referrer', // Don't leak referrer
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+          "Cache-Control": "public, max-age=300",
+          "X-Robots-Tag": "noindex",
+          "Referrer-Policy": "no-referrer",
+          "X-Content-Type-Options": "nosniff"
         }
       });
-
     } catch (error) {
-      // Log error to Cloudflare dashboard (not visible to users)
-      console.error('Kromgo fetch failed:', error.message);
-
-      // Return generic error in shields.io format
       return new Response(JSON.stringify({
         schemaVersion: 1,
-        label: 'error',
-        message: 'timeout',
-        color: 'lightgrey'
+        label: "error",
+        message: "timeout",
+        color: "lightgrey"
       }), {
         status: 503,
         headers: {
-          'Content-Type': 'application/json',
-          'Cache-Control': 'no-cache'
+          "Content-Type": "application/json",
+          "Cache-Control": "no-cache"
         }
       });
     }
   }
-}
+};
+
+export {
+  index_default as default
+};

--- a/scripts/cloudflare-worker/kromgo-proxy/test-deployment.sh
+++ b/scripts/cloudflare-worker/kromgo-proxy/test-deployment.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# Test script to verify Cloudflare Worker deployment and check for domain leakage
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Get worker URL from user
+read -p "Enter your worker URL (e.g., https://kromgo-proxy.username.workers.dev): " WORKER_URL
+read -p "Enter your secret domain to check for leaks (e.g., example.com): " SECRET_DOMAIN
+
+echo ""
+echo "Testing Cloudflare Worker: $WORKER_URL"
+echo "Checking for domain leakage: $SECRET_DOMAIN"
+echo ""
+
+# Test metrics
+METRICS=(
+  "talos_version"
+  "kubernetes_version"
+  "flux_version"
+  "cluster_node_count"
+  "cluster_pod_count"
+  "cluster_cpu_usage"
+  "cluster_memory_usage"
+  "cluster_age_days"
+  "cluster_uptime_days"
+  "cluster_alert_count"
+)
+
+PASSED=0
+FAILED=0
+LEAKED=0
+
+echo "=========================================="
+echo "Testing Metric Endpoints"
+echo "=========================================="
+
+for metric in "${METRICS[@]}"; do
+  echo -n "Testing $metric... "
+
+  # Fetch the metric with verbose output to capture headers
+  RESPONSE=$(curl -s -w "\n%{http_code}" "${WORKER_URL}/${metric}")
+  HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+  BODY=$(echo "$RESPONSE" | head -n-1)
+
+  if [ "$HTTP_CODE" = "200" ]; then
+    echo -e "${GREEN}✓ PASS${NC} (HTTP $HTTP_CODE)"
+    ((PASSED++))
+
+    # Check for domain leakage in response body
+    if echo "$BODY" | grep -qi "$SECRET_DOMAIN"; then
+      echo -e "  ${RED}⚠ DOMAIN LEAKED IN RESPONSE!${NC}"
+      echo "  Found: $(echo "$BODY" | grep -i "$SECRET_DOMAIN")"
+      ((LEAKED++))
+    fi
+
+    # Validate JSON structure
+    if echo "$BODY" | jq empty 2>/dev/null; then
+      echo "  JSON: Valid"
+    else
+      echo -e "  ${YELLOW}JSON: Invalid${NC}"
+    fi
+  else
+    echo -e "${RED}✗ FAIL${NC} (HTTP $HTTP_CODE)"
+    ((FAILED++))
+    echo "  Response: $BODY"
+  fi
+done
+
+echo ""
+echo "=========================================="
+echo "Testing Invalid Endpoints"
+echo "=========================================="
+
+# Test invalid metric (should return 404)
+echo -n "Testing invalid metric (should 404)... "
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${WORKER_URL}/invalid_metric_12345")
+if [ "$HTTP_CODE" = "404" ]; then
+  echo -e "${GREEN}✓ PASS${NC} (HTTP $HTTP_CODE)"
+  ((PASSED++))
+else
+  echo -e "${RED}✗ FAIL${NC} (HTTP $HTTP_CODE - expected 404)"
+  ((FAILED++))
+fi
+
+# Test path traversal (should return 404)
+echo -n "Testing path traversal (should 404)... "
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${WORKER_URL}/../etc/passwd")
+if [ "$HTTP_CODE" = "404" ]; then
+  echo -e "${GREEN}✓ PASS${NC} (HTTP $HTTP_CODE)"
+  ((PASSED++))
+else
+  echo -e "${RED}✗ FAIL${NC} (HTTP $HTTP_CODE - expected 404)"
+  ((FAILED++))
+fi
+
+# Test POST method (should return 405)
+echo -n "Testing POST method (should 405)... "
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "${WORKER_URL}/talos_version")
+if [ "$HTTP_CODE" = "405" ]; then
+  echo -e "${GREEN}✓ PASS${NC} (HTTP $HTTP_CODE)"
+  ((PASSED++))
+else
+  echo -e "${RED}✗ FAIL${NC} (HTTP $HTTP_CODE - expected 405)"
+  ((FAILED++))
+fi
+
+echo ""
+echo "=========================================="
+echo "Checking for Domain Leakage in Headers"
+echo "=========================================="
+
+# Check headers for domain leakage
+echo -n "Checking response headers... "
+HEADERS=$(curl -s -I "${WORKER_URL}/talos_version")
+if echo "$HEADERS" | grep -qi "$SECRET_DOMAIN"; then
+  echo -e "${RED}✗ DOMAIN LEAKED IN HEADERS!${NC}"
+  echo "$HEADERS" | grep -i "$SECRET_DOMAIN"
+  ((LEAKED++))
+else
+  echo -e "${GREEN}✓ No leakage detected${NC}"
+fi
+
+echo ""
+echo "=========================================="
+echo "Test Summary"
+echo "=========================================="
+echo "Passed: $PASSED"
+echo "Failed: $FAILED"
+echo "Domain Leaks: $LEAKED"
+echo ""
+
+if [ $FAILED -eq 0 ] && [ $LEAKED -eq 0 ]; then
+  echo -e "${GREEN}✓ All tests passed! Worker is secure and functional.${NC}"
+  exit 0
+else
+  echo -e "${RED}✗ Some tests failed. Review the output above.${NC}"
+  exit 1
+fi

--- a/scripts/cloudflare-worker/kromgo-proxy/wrangler.toml
+++ b/scripts/cloudflare-worker/kromgo-proxy/wrangler.toml
@@ -1,0 +1,36 @@
+# Cloudflare Worker Configuration for Kromgo Proxy
+#
+# This worker proxies requests to your internal Kromgo instance
+# without exposing your actual domain name.
+#
+# Deployment:
+#   1. Install wrangler: npm install -g wrangler
+#   2. Login: wrangler login
+#   3. Set secret: wrangler secret put SECRET_DOMAIN
+#   4. Deploy: wrangler deploy
+
+name = "kromgo-proxy"
+main = "src/index.js"
+compatibility_date = "2024-01-01"
+
+# Worker will be available at: https://kromgo-proxy.<your-username>.workers.dev
+# You can also add a custom domain if desired (but defeats the purpose)
+
+# Routes (none - runs on workers.dev subdomain only)
+# routes = []
+
+# Optional: Enable rate limiting with Workers KV (free tier available)
+# Uncomment to enable rate limiting feature
+# [[kv_namespaces]]
+# binding = "KV"
+# id = "your-kv-namespace-id"
+
+# Environment-specific configuration
+[env.production]
+# Secrets are set via: wrangler secret put SECRET_DOMAIN
+# Values are encrypted and never visible in code or logs
+
+# Optional: Configure custom domains (not recommended for this use case)
+# [env.production.routes]
+# pattern = "metrics.example.com/*"
+# zone_name = "example.com"


### PR DESCRIPTION
## Summary
Adds a Cloudflare Worker that proxies public access to Kromgo cluster metrics while keeping the internal domain private and handling Cloudflare Access authentication.

## Motivation
Kromgo metrics are useful for public display (e.g., GitHub profile badges, status pages) but are:
1. Behind Cloudflare Access requiring authentication
2. Hosted on an internal domain that shouldn't be publicly exposed

This worker solves both problems by acting as an authenticated proxy.

## Implementation

### Features
- **Metric whitelist**: Only exposes approved cluster metrics (versions, resource usage, alerts)
- **Cloudflare Access integration**: Handles service token authentication transparently
- **Public API**: Provides unauthenticated access to metrics in badge-compatible JSON format
- **Security hardening**:
  - Environment variable validation
  - HTTP method restrictions (GET/OPTIONS only)
  - Input validation on metric names
  - 5-second request timeout
  - Security headers (nosniff, noindex, no-referrer)
  - Generic error messages (no information leakage)
- **Performance**: 5-minute response caching
- **CORS enabled**: Cross-origin access for badge embedding

### Supported Metrics
- `talos_version` - Talos Linux version
- `kubernetes_version` - Kubernetes version
- `flux_version` - Flux CD version
- `cluster_node_count` - Number of cluster nodes
- `cluster_pod_count` - Number of running pods
- `cluster_cpu_usage` - Cluster CPU usage percentage
- `cluster_memory_usage` - Cluster memory usage percentage
- `cluster_age_days` - Days since cluster creation
- `cluster_uptime_days` - Days of continuous uptime
- `cluster_alert_count` - Active alert count

### Configuration
Requires three environment variables (configured as secrets):
- `CF_CLIENT_ID` - Cloudflare Access service token client ID
- `CF_CLIENT_SECRET` - Cloudflare Access service token secret
- `SECRET_DOMAIN` - Internal domain hosting Kromgo (not exposed publicly)

### Usage
```
https://kromgo-proxy.<sub-domain>.workers.dev/flux_version
```

Returns:
```json
{
  "schemaVersion": 1,
  "label": "Flux",
  "message": "v2.x.x",
  "color": "blue"
}
```

### Error Handling
- **404** - Invalid/disallowed metric name
- **405** - Invalid HTTP method
- **500** - Missing environment variables
- **503** - Auth failure, upstream unavailable, or timeout

## Cloudflare Access Setup
Requires a Service Auth policy in the Kromgo Cloudflare Access application:
1. Policy type: **Service Auth** (not "Allow")
2. Include: Service token matching `CF_CLIENT_ID`
3. Priority: Above any Deny policies

## Testing
- [x] All whitelisted metrics return valid responses
- [x] Invalid metrics return 404
- [x] Invalid HTTP methods return 405
- [x] CORS headers present for cross-origin access
- [x] Cloudflare Access authentication working
- [x] Response caching functional
- [x] Timeout handling for slow/hung upstream
- [x] Auth failure detection (HTML response handling)

## Security Considerations
✅ Internal domain never exposed in responses  
✅ Service tokens stored as encrypted secrets  
✅ Only specific metrics whitelisted  
✅ No sensitive error information leaked  
✅ Rate limiting available via Cloudflare  
✅ Request timeout prevents resource exhaustion  