### PR TITLE
feat(volsync): add 15-minute deterministic backup delay with jitter

### DIFF
--- a/kubernetes/apps/volsync-system/volsync/app/mutatingadmissionpolicy.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/mutatingadmissionpolicy.yaml
@@ -48,7 +48,7 @@ spec:
                 name: "jitter",
                 image: "ghcr.io/home-operations/busybox:1.37.0@sha256:026ed7273270ec08f6902b4ae8334c23b473e5394bec3bbbdbfe580c710d50bc",
                 imagePullPolicy: "IfNotPresent",
-                command: ["sh", "-c", "sleep $(shuf -i 0-30 -n 1)"]
+                command: ["sh", "-c", "APP=$(echo $HOSTNAME | sed 's/^volsync-src-//' | rev | cut -d- -f3- | rev); sleep $(($(echo $APP | cksum | awk '{print $1 % 900}') + $(shuf -i 0-30 -n 1)))"]
               }
             }
           ]


### PR DESCRIPTION
Replace the random 0-30s jitter with a hybrid approach:
- Deterministic base delay (0-15 min) based on hostname hash
- Small random jitter (0-30s) to avoid hash collisions

This spreads 20+ app backups over 15 minutes instead of 30 seconds,
reducing load on NFS and preventing thundering herd at the top of
each hour. Each app gets a consistent delay slot based on its name.

Formula: sleep $(($(echo $HOSTNAME | cksum | awk '{print $1 % 900}') + $(shuf -i 0-30 -n 1)))