### PR TITLE
fix(volsync): correct app name extraction for hyphenated apps

### DIFF
--- a/kubernetes/apps/volsync-system/volsync/app/mutatingadmissionpolicy.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/mutatingadmissionpolicy.yaml
@@ -48,7 +48,7 @@ spec:
                 name: "jitter",
                 image: "ghcr.io/home-operations/busybox:1.37.0@sha256:026ed7273270ec08f6902b4ae8334c23b473e5394bec3bbbdbfe580c710d50bc",
                 imagePullPolicy: "IfNotPresent",
-                command: ["sh", "-c", "APP=$(echo $HOSTNAME | sed 's/^volsync-src-//' | rev | cut -d- -f3- | rev); sleep $(($(echo $APP | cksum | awk '{print $1 % 900}') + $(shuf -i 0-30 -n 1)))"]
+                command: ["sh", "-c", "APP=$(echo $HOSTNAME | sed 's/^volsync-src-//' | rev | cut -d- -f2- | rev); sleep $(($(echo $APP | cksum | awk '{print $1 % 900}') + $(shuf -i 0-30 -n 1)))"]
               }
             }
           ]


### PR DESCRIPTION
Change cut -d- -f3- to cut -d- -f2- in the jitter initContainer command
to properly extract hyphenated app names like cross-seed from the job
hostname.

With f3-, the reversed hostname tx9g7-dees-ssorc (from cross-seed-7g9xt)
only captures ssorc, resulting in "cross" after reversal. Using f2-
correctly captures dees-ssorc, resulting in "cross-seed".