### PR TITLE
fix(observability): rename twingate0/1 blackbox probes to edge0/1

### DIFF
--- a/kubernetes/apps/observability/blackbox-exporter/app/probes.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/probes.yaml
@@ -17,8 +17,8 @@ spec:
         - unifi.${SECRET_DOMAIN}
         - jellyfin.${SECRET_DOMAIN}
         - s3.${SECRET_DOMAIN}
-        - twingate0.${SECRET_DOMAIN}
-        - twingate1.${SECRET_DOMAIN}
+        - edge0.${SECRET_DOMAIN}
+        - edge1.${SECRET_DOMAIN}
         - dns0.${SECRET_DOMAIN}
         - dns1.${SECRET_DOMAIN}
         - gateway0.${SECRET_DOMAIN}


### PR DESCRIPTION
## Summary
- DNS records `twingate0/twingate1.achva.casa` were deleted today and replaced with `edge0/edge1.achva.casa` (same IPs: 192.168.120.5 / 192.168.120.8 — hostname swap only, the LXCs actually run cloudflared, not Twingate).
- `blackbox-exporter` icmp `devices` Probe was the only remaining reference to the old hostnames anywhere in the repo (verified via repo-wide grep). With the records gone it returns NXDOMAIN and `probe_success` for those targets is 0.
- Updates the two static targets to the new names so probes resolve again.

## Test plan
- [ ] Flux reconciles the `blackbox-exporter` Kustomization on `main`.
- [ ] `kubectl -n observability get probe devices -o yaml` shows `edge0/edge1.${SECRET_DOMAIN}` in `spec.targets.staticConfig.static`.
- [ ] In Grafana / VM: `probe_success{instance=~"edge[01]\\.achva\\.casa"}` reports 1; `probe_dns_lookup_time_seconds` is non-zero and `probe_icmp_duration_seconds` populated.
- [ ] Confirm there are no remaining series for `instance=~"twingate[01]\\.achva\\.casa"` after the staleness window (they should drop out naturally — no recording rules or alerts reference them).