### PR TITLE
feat(observability): adopt 4 wins from onedr0p VM stack

### DIFF
--- a/kubernetes/apps/observability/grafana/instance/kustomization.yaml
+++ b/kubernetes/apps/observability/grafana/instance/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - ./grafanadatasource.yaml
   - ./grafana.yaml
   - ./httproute.yaml
+  - ./mutatingadmissionpolicy.yaml
   - ./servicemonitor.yaml

--- a/kubernetes/apps/observability/grafana/instance/mutatingadmissionpolicy.yaml
+++ b/kubernetes/apps/observability/grafana/instance/mutatingadmissionpolicy.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.36.0/mutatingadmissionpolicybinding-admissionregistration-v1.json
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicyBinding
+metadata:
+  name: grafana-image-mirror
+spec:
+  policyName: grafana-image-mirror
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.36.0/mutatingadmissionpolicy-admissionregistration-v1.json
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: grafana-image-mirror
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - deployments
+  matchConditions:
+    - name: is-grafana-deployment
+      expression: >-
+        object.metadata.name == "grafana-deployment"
+    - name: has-docker-io-grafana-image
+      expression: >-
+        object.spec.template.spec.containers.exists(c,
+          c.image.startsWith("docker.io/grafana/")
+        )
+  failurePolicy: Fail
+  reinvocationPolicy: IfNeeded
+  mutations:
+    - patchType: JSONPatch
+      jsonPatch:
+        expression: >-
+          [
+            JSONPatch{
+              op: "replace",
+              path: "/spec/template/spec/containers/0/image",
+              value: "mirror.gcr.io/grafana/" + object.spec.template.spec.containers[0].image.replace("docker.io/grafana/", "")
+            }
+          ]

--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -11,6 +11,10 @@ spec:
   interval: 1h
   upgrade:
     cleanupOnFail: false
+  valuesFrom:
+    - kind: ConfigMap
+      name: flux-metrics-configmap
+      valuesKey: flux-metrics.yaml
   values:
     fullnameOverride: stack
 

--- a/kubernetes/apps/observability/victoria-metrics/app/kustomization.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/kustomization.yaml
@@ -21,3 +21,11 @@ resources:
   - ./kea-dhcp4-dashboard.yaml
   - ./dnscrypt-proxy-dashboard.yaml
   - ./stream-aggr-config.yaml
+configMapGenerator:
+  - name: flux-metrics-configmap
+    files:
+      - flux-metrics.yaml=./resources/flux-metrics.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/observability/victoria-metrics/app/resources/flux-metrics.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/resources/flux-metrics.yaml
@@ -1,0 +1,364 @@
+---
+kube-state-metrics:
+  rbac:
+    extraRules:
+      - apiGroups:
+          - source.toolkit.fluxcd.io
+          - kustomize.toolkit.fluxcd.io
+          - helm.toolkit.fluxcd.io
+          - notification.toolkit.fluxcd.io
+        resources:
+          - gitrepositories
+          - buckets
+          - helmrepositories
+          - helmcharts
+          - ocirepositories
+          - kustomizations
+          - helmreleases
+          - alerts
+          - providers
+          - receivers
+        verbs:
+          - list
+          - watch
+  customResourceState:
+    enabled: true
+    config:
+      spec:
+        resources:
+          - groupVersionKind:
+              group: kustomize.toolkit.fluxcd.io
+              version: v1
+              kind: Kustomization
+            metricNamePrefix: gotk
+            metrics:
+              - name: resource_info
+                help: The current state of a Flux Kustomization resource.
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name:
+                        - metadata
+                        - name
+                labelsFromPath:
+                  exported_namespace:
+                    - metadata
+                    - namespace
+                  ready:
+                    - status
+                    - conditions
+                    - "[type=Ready]"
+                    - status
+                  suspended:
+                    - spec
+                    - suspend
+                  revision:
+                    - status
+                    - lastAppliedRevision
+                  source_name:
+                    - spec
+                    - sourceRef
+                    - name
+          - groupVersionKind:
+              group: helm.toolkit.fluxcd.io
+              version: v2
+              kind: HelmRelease
+            metricNamePrefix: gotk
+            metrics:
+              - name: resource_info
+                help: The current state of a Flux HelmRelease resource.
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name:
+                        - metadata
+                        - name
+                labelsFromPath:
+                  exported_namespace:
+                    - metadata
+                    - namespace
+                  ready:
+                    - status
+                    - conditions
+                    - "[type=Ready]"
+                    - status
+                  suspended:
+                    - spec
+                    - suspend
+                  revision:
+                    - status
+                    - history
+                    - "0"
+                    - chartVersion
+                  chart_name:
+                    - status
+                    - history
+                    - "0"
+                    - chartName
+                  chart_app_version:
+                    - status
+                    - history
+                    - "0"
+                    - appVersion
+                  chart_ref_name:
+                    - spec
+                    - chartRef
+                    - name
+                  chart_source_name:
+                    - spec
+                    - chart
+                    - spec
+                    - sourceRef
+                    - name
+          - groupVersionKind:
+              group: source.toolkit.fluxcd.io
+              version: v1
+              kind: GitRepository
+            metricNamePrefix: gotk
+            metrics:
+              - name: resource_info
+                help: The current state of a Flux GitRepository resource.
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name:
+                        - metadata
+                        - name
+                labelsFromPath:
+                  exported_namespace:
+                    - metadata
+                    - namespace
+                  ready:
+                    - status
+                    - conditions
+                    - "[type=Ready]"
+                    - status
+                  suspended:
+                    - spec
+                    - suspend
+                  revision:
+                    - status
+                    - artifact
+                    - revision
+                  url:
+                    - spec
+                    - url
+          - groupVersionKind:
+              group: source.toolkit.fluxcd.io
+              version: v1
+              kind: Bucket
+            metricNamePrefix: gotk
+            metrics:
+              - name: resource_info
+                help: The current state of a Flux Bucket resource.
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name:
+                        - metadata
+                        - name
+                labelsFromPath:
+                  exported_namespace:
+                    - metadata
+                    - namespace
+                  ready:
+                    - status
+                    - conditions
+                    - "[type=Ready]"
+                    - status
+                  suspended:
+                    - spec
+                    - suspend
+                  revision:
+                    - status
+                    - artifact
+                    - revision
+                  endpoint:
+                    - spec
+                    - endpoint
+                  bucket_name:
+                    - spec
+                    - bucketName
+          - groupVersionKind:
+              group: source.toolkit.fluxcd.io
+              version: v1
+              kind: HelmRepository
+            metricNamePrefix: gotk
+            metrics:
+              - name: resource_info
+                help: The current state of a Flux HelmRepository resource.
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name:
+                        - metadata
+                        - name
+                labelsFromPath:
+                  exported_namespace:
+                    - metadata
+                    - namespace
+                  ready:
+                    - status
+                    - conditions
+                    - "[type=Ready]"
+                    - status
+                  suspended:
+                    - spec
+                    - suspend
+                  revision:
+                    - status
+                    - artifact
+                    - revision
+                  url:
+                    - spec
+                    - url
+          - groupVersionKind:
+              group: source.toolkit.fluxcd.io
+              version: v1
+              kind: HelmChart
+            metricNamePrefix: gotk
+            metrics:
+              - name: resource_info
+                help: The current state of a Flux HelmChart resource.
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name:
+                        - metadata
+                        - name
+                labelsFromPath:
+                  exported_namespace:
+                    - metadata
+                    - namespace
+                  ready:
+                    - status
+                    - conditions
+                    - "[type=Ready]"
+                    - status
+                  suspended:
+                    - spec
+                    - suspend
+                  revision:
+                    - status
+                    - artifact
+                    - revision
+                  chart_name:
+                    - spec
+                    - chart
+                  chart_version:
+                    - spec
+                    - version
+          - groupVersionKind:
+              group: source.toolkit.fluxcd.io
+              version: v1
+              kind: OCIRepository
+            metricNamePrefix: gotk
+            metrics:
+              - name: resource_info
+                help: The current state of a Flux OCIRepository resource.
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name:
+                        - metadata
+                        - name
+                labelsFromPath:
+                  exported_namespace:
+                    - metadata
+                    - namespace
+                  ready:
+                    - status
+                    - conditions
+                    - "[type=Ready]"
+                    - status
+                  suspended:
+                    - spec
+                    - suspend
+                  revision:
+                    - status
+                    - artifact
+                    - revision
+                  url:
+                    - spec
+                    - url
+          - groupVersionKind:
+              group: notification.toolkit.fluxcd.io
+              version: v1beta3
+              kind: Alert
+            metricNamePrefix: gotk
+            metrics:
+              - name: resource_info
+                help: The current state of a Flux Alert resource.
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name:
+                        - metadata
+                        - name
+                labelsFromPath:
+                  exported_namespace:
+                    - metadata
+                    - namespace
+                  suspended:
+                    - spec
+                    - suspend
+          - groupVersionKind:
+              group: notification.toolkit.fluxcd.io
+              version: v1beta3
+              kind: Provider
+            metricNamePrefix: gotk
+            metrics:
+              - name: resource_info
+                help: The current state of a Flux Provider resource.
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name:
+                        - metadata
+                        - name
+                labelsFromPath:
+                  exported_namespace:
+                    - metadata
+                    - namespace
+                  suspended:
+                    - spec
+                    - suspend
+          - groupVersionKind:
+              group: notification.toolkit.fluxcd.io
+              version: v1
+              kind: Receiver
+            metricNamePrefix: gotk
+            metrics:
+              - name: resource_info
+                help: The current state of a Flux Receiver resource.
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      name:
+                        - metadata
+                        - name
+                labelsFromPath:
+                  exported_namespace:
+                    - metadata
+                    - namespace
+                  ready:
+                    - status
+                    - conditions
+                    - "[type=Ready]"
+                    - status
+                  suspended:
+                    - spec
+                    - suspend
+                  webhook_path:
+                    - status
+                    - webhookPath

--- a/kubernetes/apps/observability/vmauth/app/vmauth.yaml
+++ b/kubernetes/apps/observability/vmauth/app/vmauth.yaml
@@ -47,6 +47,7 @@ spec:
     maxConcurrentRequests: "32"
     maxConcurrentPerUserRequests: "16"
     maxIdleConnsPerBackend: "32"
+    requestBufferSize: "65536"
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
## Summary

Adopts improvements from comparing our VictoriaMetrics observability stack against onedr0p/home-ops.

- **kube-state-metrics `customResourceState` for Flux CRs** — exposes `gotk_resource_info{...}` for HelmReleases, Kustomizations, GitRepositories, OCIRepositories, HelmRepositories, HelmCharts, Buckets, Alerts, Providers, Receivers. Enables richer "is anything stuck?" alerts and dashboards beyond the default flux controller metrics.
- **Grafana MutatingAdmissionPolicy** — rewrites `docker.io/grafana/*` to `mirror.gcr.io/grafana/*` to dodge Docker Hub rate limits. Narrowly scoped to the grafana deployment only; `failurePolicy: Fail` with strict matchConditions.
- **vmauth `requestBufferSize: 65536`** — doubled from default 32768 to help with bursty Grafana panel loads / large query responses.

Note: Flux Notification Provider -> Alertmanager (the 4th win from the comparison) was already implemented at `kubernetes/components/alerts/alertmanager/`. No changes needed there.

## Test plan

- [ ] Flux reconciles cleanly after merge
- [ ] `kubectl get cm -n observability flux-metrics-configmap` exists
- [ ] `kubectl get mutatingadmissionpolicy grafana-rewrite-docker-images` exists
- [ ] vmauth pod args include `-requestBufferSize=65536`
- [ ] KSM `/metrics` exposes `gotk_resource_info` (count > 0)
- [ ] Grafana pod restarted (e.g. on next chart bump) shows `mirror.gcr.io/grafana/grafana:...` image