### PR TITLE
feat(observability): add blackbox-exporter grafana dashboard

### DIFF
--- a/kubernetes/apps/observability/blackbox-exporter/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/grafanadashboard.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schema.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: blackbox-exporter
+spec:
+  allowCrossNamespaceImport: true
+  folder: observability
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_SIGNCL-PROMETHEUS
+  # renovate: depName="Prometheus Blackbox Exporter"
+  url: https://grafana.com/api/dashboards/7587/revisions/3/download

--- a/kubernetes/apps/observability/blackbox-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./ocirepository.yaml
   - ./helmrelease.yaml
   - ./probes.yaml
+  - ./grafanadashboard.yaml


### PR DESCRIPTION
## Summary

Adds Grafana dashboard #7587 (Prometheus Blackbox Exporter) for visualizing our 3 existing Probe targets. Adapted from onedr0p/home-ops [75b2f07](https://github.com/onedr0p/home-ops/commit/75b2f079925fa1d6ffba1daf5bc4942ae2a25ae8) to match our conventions:

- `instanceSelector`: `grafana.internal/instance: grafana`
- `datasourceName: prometheus`
- `folder: observability`
- Renovate annotation for tracking dashboard revisions

## Test plan

- [ ] Flux reconciles cleanly
- [ ] `kubectl get grafanadashboard -n observability blackbox-exporter` exists with status Ready
- [ ] Dashboard appears in Grafana under the "observability" folder
- [ ] Panels populate with data from existing Probe targets