### PR TITLE
refactor(volsync): decouple cache vars from snapshot capacity

### DIFF
--- a/kubernetes/components/volsync/replicationdestination.yaml
+++ b/kubernetes/components/volsync/replicationdestination.yaml
@@ -14,8 +14,8 @@ spec:
       - ${VOLSYNC_ACCESSMODES:=ReadWriteOnce}
     cacheAccessModes:
       - ${VOLSYNC_CACHE_ACCESSMODES:=ReadWriteOnce}
-    cacheCapacity: ${VOLSYNC_CAPACITY:=5Gi}
-    cacheStorageClassName: ${VOLSYNC_CACHE_SNAPSHOTCLASS:=openebs-hostpath}
+    cacheCapacity: ${VOLSYNC_CACHE_CAPACITY:=5Gi}
+    cacheStorageClassName: ${VOLSYNC_CACHE_STORAGECLASS:=openebs-hostpath}
     capacity: ${VOLSYNC_CAPACITY:=5Gi}
     cleanupCachePVC: true
     cleanupTempPVC: true

--- a/kubernetes/components/volsync/replicationsource.yaml
+++ b/kubernetes/components/volsync/replicationsource.yaml
@@ -13,8 +13,8 @@ spec:
       - ${VOLSYNC_SNAP_ACCESSMODES:=ReadWriteOnce}
     cacheAccessModes:
       - ${VOLSYNC_CACHE_ACCESSMODES:=ReadWriteOnce}
-    cacheCapacity: ${VOLSYNC_CAPACITY:=5Gi}
-    cacheStorageClassName: ${VOLSYNC_CACHE_SNAPSHOTCLASS:=openebs-hostpath}
+    cacheCapacity: ${VOLSYNC_CACHE_CAPACITY:=5Gi}
+    cacheStorageClassName: ${VOLSYNC_CACHE_STORAGECLASS:=openebs-hostpath}
     compression: zstd-fastest
     copyMethod: ${VOLSYNC_COPYMETHOD:=Snapshot}
     moverSecurityContext:


### PR DESCRIPTION
## Summary

Cleanup of two issues in our VolSync component templates inspired by [onedr0p/home-ops 7353665](https://github.com/onedr0p/home-ops/commit/7353665836a0a81ebc0ed2d889516df951eae285):

- **`VOLSYNC_CACHE_SNAPSHOTCLASS` -> `VOLSYNC_CACHE_STORAGECLASS`** — the field it feeds is `cacheStorageClassName`, not a snapshot class. The old name was misleading. No apps override this var, so it's a safe rename — only the default value flows through.
- **Decouple `cacheCapacity` from `VOLSYNC_CAPACITY`** — both the snapshot's `capacity` and the kopia cache PVC's `cacheCapacity` were resolving to the same `${VOLSYNC_CAPACITY}` var. Result: pocket-id (1Gi snap) had a 1Gi kopia index cache (likely too small), qbittorrent (15Gi snap) had a 15Gi cache (massively oversized). New `VOLSYNC_CACHE_CAPACITY` defaults to 5Gi independent of snapshot size.

Onedr0p added the cache fields for the first time in 7353665; we already had them but inherited the same capacity-coupling oversight. This goes one better than the source commit by separating the two.

## Blast radius

- `grep -rn 'VOLSYNC_CACHE_SNAPSHOTCLASS' kubernetes/` -> only the two component template files.
- `grep -rn 'VOLSYNC_CACHE_CAPACITY' kubernetes/` -> none (new var).
- All 17 RS resources will get a 5Gi cache PVC after reconcile (most already had this via the old default).
- VolSync mover will recreate the cache PVCs on next backup run if the storage class name changed (it didn't — same default `openebs-hostpath`).

## Test plan

- [ ] Flux reconciles cleanly across all apps using the volsync component
- [ ] After next hourly backup window, all 17 ReplicationSources still report `latestMoverStatus.result: Successful`
- [ ] No new error events in volsync-system namespace