### PR TITLE
feat(flux): replace wait: true with explicit healthChecks on parent KSes

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
@@ -13,7 +13,12 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: actions-runner-system
-  wait: true
+  wait: false
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: actions-runner-controller
+      namespace: actions-runner-system
 ---
 # yaml-language-server: $schema=https://kubernetes-schema.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/kubernetes/apps/database/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/ks.yaml
@@ -16,4 +16,9 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: true
+  wait: false
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: cloudnative-pg
+      namespace: database

--- a/kubernetes/apps/external-secrets/external-secrets/ks.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/ks.yaml
@@ -13,4 +13,9 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: external-secrets
-  wait: true
+  wait: false
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: external-secrets
+      namespace: external-secrets

--- a/kubernetes/apps/flux-system/flux-operator/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/ks.yaml
@@ -13,4 +13,9 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: flux-system
-  wait: true
+  wait: false
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: flux-operator
+      namespace: flux-system

--- a/kubernetes/apps/kube-system/snapshot-controller/ks.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/ks.yaml
@@ -18,4 +18,4 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: kube-system
-  wait: true
+  wait: false

--- a/kubernetes/apps/observability/grafana/ks.yaml
+++ b/kubernetes/apps/observability/grafana/ks.yaml
@@ -13,7 +13,12 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: observability
-  wait: true
+  wait: false
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: grafana-operator
+      namespace: observability
 ---
 # yaml-language-server: $schema=https://kubernetes-schema.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/kubernetes/apps/observability/keda/ks.yaml
+++ b/kubernetes/apps/observability/keda/ks.yaml
@@ -13,4 +13,9 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: observability
-  wait: true
+  wait: false
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: keda
+      namespace: observability

--- a/kubernetes/apps/observability/silence-operator/ks.yaml
+++ b/kubernetes/apps/observability/silence-operator/ks.yaml
@@ -13,7 +13,12 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: observability
-  wait: true
+  wait: false
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: silence-operator
+      namespace: observability
 ---
 # yaml-language-server: $schema=https://kubernetes-schema.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/kubernetes/apps/openebs-system/openebs/ks.yaml
+++ b/kubernetes/apps/openebs-system/openebs/ks.yaml
@@ -18,4 +18,4 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: openebs-system
-  wait: true
+  wait: false

--- a/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -13,7 +13,12 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: rook-ceph
-  wait: true
+  wait: false
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: rook-ceph
+      namespace: rook-ceph
 ---
 # yaml-language-server: $schema=https://kubernetes-schema.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/kubernetes/apps/system-upgrade/tuppr/ks.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/ks.yaml
@@ -13,7 +13,12 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: system-upgrade
-  wait: true
+  wait: false
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: tuppr
+      namespace: system-upgrade
 ---
 # yaml-language-server: $schema=https://kubernetes-schema.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1


### PR DESCRIPTION
## Summary

- Extends the precedent set by 3829632c (volsync fix) to remaining parent Kustomizations cluster-wide.
- The kstatus library that backs Flux's `wait: true` semantics stalls indefinitely on resources without a status subresource (e.g. v1 `MutatingAdmissionPolicy`/`MutatingAdmissionPolicyBinding`, plain ConfigMaps). This holds parent KSes in `Reconciling` and trips `flux-reconcile-failed` alerts during commit storms even when every workload in the path is healthy.
- Each affected KS is switched to `wait: false` plus an explicit `healthChecks` block scoped to its top-level HelmRelease. The HR's status accurately reflects readiness without dragging status-less manifests in the same path into the wait set.

## Migrated KSes (and their healthChecks targets)

| Kustomization | Path | HelmRelease |
|---|---|---|
| `actions-runner-controller` | `actions-runner-system/actions-runner-controller/app` | `actions-runner-controller` |
| `cloudnative-pg` | `database/cloudnative-pg/app` | `cloudnative-pg` |
| `external-secrets` | `external-secrets/external-secrets/app` | `external-secrets` |
| `flux-operator` | `flux-system/flux-operator/app` | `flux-operator` |
| `grafana` | `observability/grafana/app` | `grafana-operator` |
| `keda` | `observability/keda/app` | `keda` |
| `rook-ceph` | `rook-ceph/rook-ceph/app` | `rook-ceph` |
| `silence-operator` | `observability/silence-operator/app` | `silence-operator` |
| `tuppr` | `system-upgrade/tuppr/app` | `tuppr` |
| `openebs` | `openebs-system/openebs/app` | `openebs` (already declared, just flipped `wait`) |
| `snapshot-controller` | `kube-system/snapshot-controller/app` | `snapshot-controller` (already declared, just flipped `wait`) |

## Intentionally untouched

| Kustomization | Reason |
|---|---|
| `kgateway-gateway-api-crds` | Targets CRDs only; kstatus handles `Established` correctly. |
| `prometheus-operator-crds` | Targets CRDs only; kstatus handles `Established` correctly. |
| `certificates-import` | Path holds a single `ExternalSecret` (which has status). Leaving `wait: true` is fine — flagged for human review on whether `wait` is needed at all. |
| `vmauth` | Path holds a `VMAuth` CR (status-bearing) but no HelmRelease. `wait: true` is safe here — flagged for human review. |
| `volsync` | Already migrated in 3829632c. |

## Test plan

- [x] `kubectl kustomize` builds cleanly for every touched `path:` (11 paths, all OK)
- [x] `flux build kustomization <name> --path <path> --kustomization-file <ks> --dry-run` succeeds for every migrated KS
- [x] `yq` parses every modified `ks.yaml`
- [x] No formatting drive-bys or scope creep (only `wait` and `healthChecks` fields touched)
- [ ] Post-merge: `flux reconcile source git flux-system -n flux-system` and `flux get ks -A | grep -v True` returns empty (or only known-broken nas01-related entries)