### PR TITLE
fix(observability): correct misfiring VMRules for DNS cache and VL ingestion

### DIFF
--- a/kubernetes/apps/observability/victoria-logs/app/vmrule-health.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/vmrule-health.yaml
@@ -38,22 +38,31 @@ spec:
             severity: critical
 
         - alert: VictoriaLogsIngestionStalled
+          # vl_rows_ingested_total is broken out by `type` label (nativeinsert,
+          # syslog_udp, syslog_tcp, elasticsearch_bulk, ...). Without sum() this rule
+          # fires per-type, so any historically-used ingest path that goes idle (e.g.
+          # an experimental Vector instance that was decommissioned) makes this alert
+          # fire even though aggregate ingestion is healthy. Aggregate cluster-wide so
+          # the alert only fires when ALL ingestion paths are zero.
+          # Per-type stalls are covered by SyslogIngestionStalled below; add similar
+          # per-type rules if a specific path becomes critical to monitor.
           expr: |-
-            rate(vl_rows_ingested_total{job="victoria-logs-server"}[10m]) == 0
+            sum(rate(vl_rows_ingested_total{job="victoria-logs-server"}[10m])) == 0
           for: 15m
           keep_firing_for: 5m
           annotations:
             summary: >-
               VictoriaLogs log ingestion has stalled
             description: >-
-              VictoriaLogs has not ingested any logs in the last 15 minutes. Check vlagent collector and syslog listeners.
+              VictoriaLogs has not ingested any logs in the last 15 minutes across all ingestion paths. Check vlagent collector and syslog listeners.
             runbook_url: https://docs.victoriametrics.com/victorialogs/
           labels:
             severity: warning
 
         - alert: VictoriaLogsHighIngestionRate
+          # Aggregate across types — see VictoriaLogsIngestionStalled for context.
           expr: |-
-            rate(vl_rows_ingested_total{job="victoria-logs-server"}[5m]) > 100000
+            sum(rate(vl_rows_ingested_total{job="victoria-logs-server"}[5m])) > 100000
           for: 15m
           keep_firing_for: 5m
           annotations:

--- a/kubernetes/apps/observability/victoria-metrics/app/vmrule-network-infra.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/vmrule-network-infra.yaml
@@ -111,28 +111,30 @@ spec:
           # not require a recursor lookup beyond the packet cache.
           #   (dnsdist_hits + recursor_packetcache_hits) / total_queries
           # Total queries are taken from dnsdist_queries (all queries ingress the stack
-          # through dnsdist). Threshold lowered to <70% (typical healthy: 85-90%).
-          # NOTE: dnsdist scrapes on :8083 and pdns-recursor on :8092 on the
-          # same hosts, so raw `instance` labels differ between the two layers
-          # and `sum by (instance)` + `+` will NOT align them (returns empty).
-          # We strip the :port via label_replace and aggregate by the resulting
-          # `host` label so the two layers combine per-host.
+          # through dnsdist). Threshold: <70% (cluster-wide steady state ~85-90%).
+          #
+          # 2026-05-02: switched to CLUSTER-WIDE aggregation. The previous per-host
+          # formula was load-bearing-broken: each host's dnsdist forwards round-robin
+          # to BOTH recursors, so the recursor packetcache_hits on host X include cross-
+          # host traffic, while dnsdist_queries on host X only counts local ingress.
+          # That mismatch produced numbers that exceeded 100% on the lighter-loaded
+          # node and dipped well below 70% on the busier node, generating chronic
+          # info-severity false positives. Cluster-wide aggregation is exact under
+          # active/active load balancing and is what we actually care about: the user-
+          # facing cache effectiveness across the HA pair.
           expr: |-
             (
-              (
-                sum by (host) (label_replace(rate(dnsdist_cache_hits{job="dnsdist"}[15m]), "host", "$1", "instance", "([^:]+):.*"))
-                +
-                sum by (host) (label_replace(rate(pdns_recursor_packetcache_hits{job="pdns-recursor"}[15m]), "host", "$1", "instance", "([^:]+):.*"))
-              )
-              /
-              clamp_min(
-                sum by (host) (label_replace(rate(dnsdist_queries{job="dnsdist"}[15m]), "host", "$1", "instance", "([^:]+):.*"))
-              , 1)
-            ) < 0.7
+              sum(rate(dnsdist_cache_hits{job="dnsdist"}[15m]))
+              +
+              sum(rate(pdns_recursor_packetcache_hits{job="pdns-recursor"}[15m]))
+            )
+            /
+            clamp_min(sum(rate(dnsdist_queries{job="dnsdist"}[15m])), 1)
+            < 0.7
           for: 1h
           keep_firing_for: 5m
           annotations:
-            summary: "Effective DNS cache hit ratio <70% on {{ $labels.host }}"
+            summary: "Effective DNS cache hit ratio <70% (cluster-wide)"
             description: |-
               Combined dnsdist + recursor packet cache hit ratio: {{ $value | humanizePercentage }} for 1h.
               Typical healthy value is 85-90%. Likely a warming period after restart, unusual query


### PR DESCRIPTION
## Summary

Resolves two chronically firing alerts whose root cause was misformed PromQL, not a real fault:

- **DNSCacheHitRatioLow** — per-host formula mismatched populations (dnsdist round-robins across both recursors → recursor `packetcache_hits` on host X include cross-host traffic, while `dnsdist_queries` on host X is local-only). One node clamped >100% (silent), the other dipped <70% (chronic info-noise). Switched to cluster-wide aggregation, which is exact under active/active load balancing. Verified cluster-wide hit rate is currently **87.2%** and the new expression evaluates empty.
- **VictoriaLogsIngestionStalled** / **VictoriaLogsHighIngestionRate** — missing `sum()` over the `type` label. `vl_rows_ingested_total` carries one series per ingest path ever observed (`nativeinsert`, `syslog_udp`, `elasticsearch_bulk`, ...); when any one path goes idle, its counter freezes and the un-summed `rate(...) == 0` rule fires even though aggregate ingestion is healthy. Triggered today by a now-idle external `elasticsearch_bulk` shipper (~3.4M rows, stopped 2026-05-02 11:20 UTC). Wrap both rules in `sum()`. `SyslogIngestionStalled` already pins `type="syslog_udp"` and remains the template for per-path rules if a specific path becomes load-bearing.

No threshold-bumping, no silences, no service restarts — these are root-cause rule corrections.

## Test plan

- [x] Verified new DNS cache expression evaluates empty against live data (cluster-wide hit rate ~87%).
- [x] Verified new VL ingestion expression evaluates empty against live data.
- [x] Confirmed `SyslogIngestionStalled` (per-`type` pinned) still works as expected.
- [x] Confirmed via image inspection that the cluster runs `victoriametrics/vlagent` (not Vector / Fluent-Bit) — no shipper repair is needed.
- [ ] After Flux reconcile, confirm both alerts clear in AlertManager (`VictoriaLogsIngestionStalled` clears within ~15m; `DNSCacheHitRatioLow` clears within ~1h due to the existing `for: 1h` window).

## Out of scope (followup observations, not addressed here)

- dns-0 recursor `packetcache_hits` is anomalously low vs dns-1 (33K vs 583K over 16d uptime) with identical config — worth a separate investigation.
- An external `elasticsearch_bulk` shipper hit `logs.achva.casa/insert/elasticsearch/_bulk` for ~18h on 2026-05-01/02; source not pinned to any infra VM. Likely a workstation / ad-hoc trial. No cluster impact.