### PR TITLE
fix(observability): set VL syslog parser TZ to fix 4h _time skew

### DIFF
--- a/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
@@ -45,6 +45,15 @@ spec:
         # Each value must be a JSON array (VictoriaLogs parses as JSON)
         syslog.streamFields.udp: '["hostname","app_name"]'
         syslog.streamFields.tcp: '["hostname","app_name"]'
+        # RFC3164 has no timezone in its timestamp; VyOS and UniFi APs send local
+        # wall-clock time (US/Eastern, UTC-4 during EDT) but VL parses the bare
+        # MMM DD HH:MM:SS as UTC, producing a 4h skew on _time. Tell VL the
+        # source TZ so parsed timestamps land correctly.
+        # Cisco IOS (SC01, gateway1) is unaffected: its non-canonical "<seq>: host: ..."
+        # header makes VL's RFC3164 parser bail on the timestamp entirely and fall back
+        # to receive time, so the TZ flag is a no-op for those devices — no regression
+        # risk on Cisco-sourced logs from setting this.
+        syslog.timezone: "America/New_York"
       resources:
         requests:
           cpu: 175m


### PR DESCRIPTION
## Summary

Predecessor: #1031 (corrected misfiring VL ingestion VMRule). That cleared the false alerts; this PR addresses the *parser-side* time skew that was masking "is device X sending logs right now?" queries.

### Root cause

VictoriaLogs records RFC3164 syslog from VyOS routers and UniFi APs with `_time` ~4h behind wall clock. Confirmed against a live sample on 2026-05-02: a record whose `_msg` body embedded `time=2026-05-02T21:56:46.637Z` was stored with `_time=2026-05-02T17:56:46Z` — the offset matches US/Eastern (UTC-4, EDT) exactly.

RFC3164's `MMM DD HH:MM:SS` header has no timezone field. VyOS and UniFi APs stamp lines in local wall-clock time, but VL's parser treats the bare timestamp as UTC and writes it back verbatim, producing the skew.

### Fix (one line)

Add `--syslog.timezone=America/New_York` to the VL server `extraArgs` so the parser interprets the bare RFC3164 timestamp in the source TZ.

### Why we are NOT touching Cisco device config

Cisco IOS (SC01, and gateway1 once onboarded) sends non-canonical `<seq>: hostname: Mon DD HH:MM:SS TZ: ...` syslog. VL's RFC3164 timestamp parser bails on this header entirely and falls back to receive-time stamping — `_time` on Cisco-sourced lines is already correct via the receive-time path. The TZ flag is a no-op for those devices, and changing IOS `service timestamps` formatting carries unnecessary regression risk (every downstream consumer that's adapted to today's format would have to be re-validated). Leave Cisco devices alone.

### What's in this PR
- `kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml` — add `syslog.timezone: \"America/New_York\"` plus an inline comment block explaining the VyOS/UniFi RFC3164 TZ-less behavior and why Cisco is unaffected.

### What's NOT in this PR
- No dashboard changes. The current `network-syslog-dashboard` keys Cisco panels on `facility:23` (not `hostname`), so the empty-hostname issue from the parser doesn't break any existing panel. There's nothing to apply a LogsQL `extract` pattern *to* without inventing a new panel — deferred to follow-up if/when a hostname-keyed Cisco panel is requested.
- No Cisco device-side timestamp changes (rationale above).

### Post-merge verification plan
- [ ] After Flux reconcile, confirm VL pod restarted with the new arg: `kubectl -n observability get pod -l app.kubernetes.io/name=victoria-logs -o jsonpath='{.items[*].spec.containers[*].args}' | tr ',' '\n' | grep syslog.timezone`
- [ ] Send a test line from gateway0 (`logger -p local7.info \"vl-tz-test gateway0 $(date -u +%FT%TZ)\"`) and confirm the resulting record's `_time` is within ~1 minute of real wall clock when queried with `start=5m` (no 4h offset workaround needed).
- [ ] Same test from a UniFi AP (LoftAP) — confirm `_time` lands in the recent window.
- [ ] Regression check on SC01: `facility:23` panel in the network-syslog dashboard continues to show recent traffic on a normal `start=15m` window. (Cisco was always using receive-time fallback, so this should be unchanged.)
- [ ] Regression check on gateway1 (ISR 4321): same as SC01 — receive-time fallback path, no change expected.
- [ ] Retire the `vl-syslog-time-skew` agent memory once verified (no more `start=4h5m` workaround).

## Test plan
- [x] Verified `syslog.timezone` is the correct VL flag for parser-side TZ interpretation (consistent with VL's `--syslog.streamFields` family of flags).
- [x] Verified no existing dashboard panels key on Cisco `hostname` (would be broken by Cisco's empty-hostname parse fallback regardless of this PR).
- [x] Confirmed Cisco timestamp-parse-bail behavior via the existing `cisco-syslog-empty-hostname` agent memory and dashboard inspection (Cisco panels use `facility:23`).
- [ ] Post-merge: VL pod restart verification + gateway0/LoftAP/SC01/gateway1 sample-line checks (see above).