### PR TITLE
feat(observability): mTLS auth on friday3-diagnostics webhook receiver

### DIFF
--- a/kubernetes/apps/observability/victoria-metrics/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/externalsecret.yaml
@@ -16,6 +16,12 @@ spec:
         ALERTMANAGER_HEARTBEAT_URL: "{{ .ALERTMANAGER_HEARTBEAT_URL }}"
         ALERTMANAGER_PUSHOVER_TOKEN: "{{ .ALERTMANAGER_PUSHOVER_TOKEN }}"
         PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"
+        # mTLS client cert for posting to friday3.${SECRET_DOMAIN}/webhooks/amdiag.
+        # Cert/key minted from the friday3 client CA on varunlnx0
+        # (CN=alertmanager.observability, valid until 2027-05-07).
+        friday3-client.crt: "{{ .FRIDAY3_CLIENT_CRT }}"
+        friday3-client.key: "{{ .FRIDAY3_CLIENT_KEY }}"
+        friday3-ca.crt: "{{ .FRIDAY3_CA_CRT }}"
   dataFrom:
     - extract:
         key: pushover

--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -124,6 +124,11 @@ spec:
       annotations: {}
       spec:
         replicaCount: 1
+        # Mount alertmanager-secret as files at /etc/vm/secrets/alertmanager-secret/
+        # so http_config.tls_config in webhook receivers can reference cert_file /
+        # key_file paths.  Used by friday3-diagnostics receiver below for mTLS.
+        secrets:
+          - alertmanager-secret
         port: "9093"
         selectAllByDefault: true
         externalURL: ""
@@ -203,7 +208,17 @@ spec:
               - send_resolved: true
                 timeout: 10s
                 max_alerts: 5
-                url: http://192.168.120.14:8644/webhooks/amdiag
+                # mTLS via Caddy on varunlnx0 → 127.0.0.1:8644 Hermes webhook.
+                # Caddy's client_auth { mode require_and_verify } is the AuthN gate;
+                # client cert is minted from the friday3 client CA, mounted via
+                # alertmanager-secret (see secrets: above).  No HMAC needed since
+                # the only path to /webhooks/amdiag is through the cert gate.
+                url: https://friday3.${SECRET_DOMAIN}/webhooks/amdiag
+                http_config:
+                  tls_config:
+                    server_name: friday3.${SECRET_DOMAIN}
+                    cert_file: /etc/vm/secrets/alertmanager-secret/friday3-client.crt
+                    key_file:  /etc/vm/secrets/alertmanager-secret/friday3-client.key
           - name: pushover
             pushover_configs:
               - html: true


### PR DESCRIPTION
## Summary

Replaces plaintext `http://192.168.120.14:8644/webhooks/amdiag` with mTLS-gated `https://friday3.\${SECRET_DOMAIN}/webhooks/amdiag`. Caddy on varunlnx0 already terminates mTLS for the friday3 dashboard; this adds a path-handle for `/webhooks/*` that proxies to the loopback-bound Hermes webhook.

**Why now:** Upstream Hermes (just upgraded — 229 commits forward) added a startup safety check that refuses `INSECURE_NO_AUTH` secret combined with a non-loopback bind. The receiver was previously running with no auth at all, relying on firewall isolation alone. Webhook now refuses to start until either (a) bound to loopback, or (b) given a real secret. This PR moves Hermes to loopback-only and pushes the auth boundary to Caddy where mTLS already lives.

**Auth model after this lands:**

\`\`\`
Alertmanager pod                Caddy on varunlnx0              Hermes webhook
http_config.tls_config:    →    friday3.\${SECRET_DOMAIN}    →   127.0.0.1:8644
  cert_file / key_file          client_auth: require+verify      (loopback only)
                                trust_pool: ~/.friday3/ca
\`\`\`

Single auth boundary (cert-based). No HMAC layer — the only path to `/webhooks/amdiag` is through the cert gate.

## Changes

**\`externalsecret.yaml\`**
- Adds 3 new template fields (\`friday3-client.crt\`, \`friday3-client.key\`, \`friday3-ca.crt\`) pulled from the existing \`alertmanager\` 1Password item

**\`helmrelease.yaml\`**
- Adds \`secrets: [alertmanager-secret]\` to \`vmalertmanager.spec\` so the secret mounts as files at \`/etc/vm/secrets/alertmanager-secret/\`
- Replaces \`url:\` and adds \`http_config.tls_config\` to the \`friday3-diagnostics\` webhook receiver

## Out-of-band changes already done (varunlnx0)

- ✅ Cert minted (CN=alertmanager.observability, valid 2026-05-07 → 2027-05-07, EKU=clientAuth, signed by ~/.friday3/ca/ca.crt)
- ✅ 3 PEM blobs uploaded to \`Infrastructure/alertmanager\` 1Password item via \`op item edit\`
- ✅ Caddyfile extended with \`handle /webhooks/* { reverse_proxy 127.0.0.1:8644 }\` inside the existing friday3 mTLS block
- ✅ Hermes \`config.yaml\` webhook host \`0.0.0.0\` → \`127.0.0.1\`
- ✅ Hermes restart, webhook log shows \`Listening on 127.0.0.1:8644 — routes: amdiag\`

## Local smoke test results (pre-merge)

| Test | Expected | Actual |
|---|---|---|
| GET without client cert | TLS handshake fail | \`tlsv13 alert certificate required\` ✓ |
| GET with cert | 405 Method Not Allowed (POST-only) | HTTP 405 ✓ |
| POST with cert + alert payload | 202 Accepted, agent run queued | HTTP 202, delivery_id assigned, Friday processed ✓ |

## Test plan after merge

- [ ] Flux reconcile: \`flux reconcile kustomization observability-victoria-metrics -n flux-system\`
- [ ] AlertManager pod restarts cleanly (check secret mount exists at \`/etc/vm/secrets/alertmanager-secret/\`)
- [ ] Trigger a real test alert (or wait for next legitimate alert): observe \`[webhook] POST event=... route=amdiag\` in \`~/.hermes/logs/agent.log\` on varunlnx0
- [ ] Confirm Discord #alerts channel receives the diagnostic
- [ ] Confirm pushover still receives in parallel (continue: true on the route)

## Renewal

Cert valid until **2027-05-07**. Local mirror at \`~/.friday3/clients/alertmanager/{cert,key}.pem\` for re-mint via the same \`openssl x509 -req\` pattern. Consider folding into AAP JT 21 next renewal cycle.