### PR TITLE
fix(observability): use cert_secret_ref schema for VMAlertmanagerConfig

### DIFF
--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -215,11 +215,10 @@ spec:
                 http_config:
                   tls_config:
                     server_name: friday3.${SECRET_DOMAIN}
-                    cert:
-                      secret:
-                        name: alertmanager-secret
-                        key: friday3-client.crt
-                    key_secret:
+                    cert_secret_ref:
+                      name: alertmanager-secret
+                      key: friday3-client.crt
+                    key_secret_ref:
                       name: alertmanager-secret
                       key: friday3-client.key
           - name: pushover


### PR DESCRIPTION
Third attempt at the friday3-diagnostics tls_config schema. Operator's strict JSON unmarshal rejects both Prometheus-style `cert_file` and the VMAlertmanagerConfig CRD's documented `cert: { secret }` / `key_secret` shapes. The actual operator field naming convention is the snake_case _secret_ref suffix (matches `vmalertmanager.spec.gossipConfig.tls_client_config` and other internal refs throughout the operator).

Same payload, just the field names match what the operator parses.