### PR TITLE
fix(observability): camelCase tls_config field names for VMAlertmanagerConfig

### DIFF
--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -214,11 +214,17 @@ spec:
                 url: https://friday3.${SECRET_DOMAIN}/webhooks/amdiag
                 http_config:
                   tls_config:
-                    server_name: friday3.${SECRET_DOMAIN}
-                    cert_secret_ref:
-                      name: alertmanager-secret
-                      key: friday3-client.crt
-                    key_secret_ref:
+                    # Operator's TLSConfig struct uses camelCase JSON tags
+                    # (serverName / cert / keySecret), unlike the surrounding
+                    # snake_case AM-config keys.  Verified against
+                    # github.com/VictoriaMetrics/operator (v0.69.0)
+                    # api/operator/v1beta1/vmextra_types.go.
+                    serverName: friday3.${SECRET_DOMAIN}
+                    cert:
+                      secret:
+                        name: alertmanager-secret
+                        key: friday3-client.crt
+                    keySecret:
                       name: alertmanager-secret
                       key: friday3-client.key
           - name: pushover


### PR DESCRIPTION
Final fix for the friday3-diagnostics tls_config schema. Verified against operator source (v0.69.0 `vmextra_types.go`):

The inner TLSConfig type uses **camelCase JSON tags** (serverName / cert / keySecret) even though the surrounding HTTPConfig uses snake_case. Three previous attempts all failed because they used snake_case for the inner fields (cert_file → unknown, key_secret → unknown, cert_secret_ref → unknown).