### PR TITLE
fix(autobrr): allow slow startup during upgrade

### DIFF
--- a/kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
@@ -9,6 +9,7 @@ spec:
     kind: OCIRepository
     name: autobrr
   interval: 1h
+  timeout: 10m
   values:
     controllers:
       autobrr:
@@ -69,6 +70,16 @@ spec:
                   timeoutSeconds: 5
                   failureThreshold: 5
               readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/healthz/liveness
+                    port: *port
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 60
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
## Summary
- adds a startupProbe for autobrr so v1.78.0 can finish SQLite integrity/backup startup before liveness begins killing it
- extends the HelmRelease timeout to 10m to allow Recreate + RWO PVC detach/attach + slow startup

## Validation
- `kubectl -n downloads apply --dry-run=client -f kubernetes/apps/downloads/autobrr/app/helmrelease.yaml`
- `flux build kustomization autobrr --path ./kubernetes/apps/downloads/autobrr/app --kustomization-file ./kubernetes/apps/downloads/autobrr/ks.yaml --dry-run`
- `kubectl -n downloads apply --dry-run=client -f /tmp/autobrr-built.yaml`

## Notes
This keeps the desired autobrr image at v1.78.0 and should unblock Flux/Helm from retrying the previously failed generation cleanly.
