### PR TITLE
fix(netbox): relax probe timeouts to stop crash-loop under load

### DIFF
--- a/kubernetes/apps/self-hosted/netbox/app/helmrelease.yaml
+++ b/kubernetes/apps/self-hosted/netbox/app/helmrelease.yaml
@@ -185,8 +185,8 @@ spec:
     readinessProbe:
       enabled: true
       initialDelaySeconds: 5
-      periodSeconds: 10
-      timeoutSeconds: 5
+      periodSeconds: 15
+      timeoutSeconds: 15  # was 5; the app gets slow under load and was flapping
       failureThreshold: 6
       successThreshold: 1
 
@@ -200,9 +200,9 @@ spec:
         path: /api/
         port: http
       initialDelaySeconds: 30
-      periodSeconds: 10
-      timeoutSeconds: 5
-      failureThreshold: 6
+      periodSeconds: 30   # was 10; lower frequency reduces probe-induced load
+      timeoutSeconds: 15  # was 5; matches readiness timeout
+      failureThreshold: 6 # 90s with 15s timeout × 6 = ~3 min before kill
       successThreshold: 1
 
     # Service account


### PR DESCRIPTION
## Summary

NetBox pod has been crash-looping intermittently (3 restarts in 29h). Liveness probe fails with context-deadline-exceeded on the 5s timeout. The `/api/` endpoint does session auth + plugin loading and was responding in 5-6s under load.

## Changes

- `readinessProbe.timeoutSeconds` 5 → 15
- `readinessProbe.periodSeconds` 10 → 15
- `customLivenessProbe.timeoutSeconds` 5 → 15
- `customLivenessProbe.periodSeconds` 10 → 30 (lower frequency reduces probe-induced load)

`failureThreshold` left at 6 → ~3 min total before kill, appropriate for an app that legitimately needs that long on a slow query.

## Test plan

- [x] Resource usage confirmed fine (11m CPU, 665Mi RAM) — this is probe tuning, not capacity
- [ ] After Flux applies: pod stays Ready, no restarts for 1h
- [ ] Backfill --apply (in flight) doesn't trigger new crashes
