### PR TITLE
fix(image-pull): pull without running the entrypoint; silence prepull alert noise

### DIFF
--- a/.github/workflows/image-pull.yaml
+++ b/.github/workflows/image-pull.yaml
@@ -167,9 +167,14 @@ jobs:
           }
           trap cleanup EXIT
 
-          # We do NOT override the image's command: the pull is proven by the absence
-          # of an image-pull error regardless of whether the entrypoint runs/exits/crashes
-          # (distroless-safe). Tolerate all taints so it warms control-plane nodes too.
+          # kubelet pulls the image BEFORE it tries to exec the container command, so we
+          # override command with a guaranteed-nonexistent path: the pull still happens,
+          # but the container fails to start instantly (StartError) instead of running the
+          # real entrypoint. This is distroless-safe (no shell needed), avoids executing
+          # arbitrary app code on every node (incl. control-plane), and never OOMKills — so
+          # it produces no false KubernetesPodOOMKilled telemetry. The warm-detection below
+          # already treats StartError/RunContainerError as "image present".
+          # Tolerate all taints so it warms control-plane nodes too.
           kubectl apply --server-side -f - <<EOF
           apiVersion: apps/v1
           kind: DaemonSet
@@ -195,12 +200,14 @@ jobs:
                   - name: prepull
                     image: "${MATRIX_IMAGE}"
                     imagePullPolicy: IfNotPresent
+                    # Nonexistent path: kubelet pulls the image, then exec fails with
+                    # StartError. The entrypoint never runs, so nothing to OOM and no
+                    # memory limit needed.
+                    command: ["/__prepull_noop_does_not_exist__"]
                     resources:
                       requests:
                         cpu: 5m
                         memory: 16Mi
-                      limits:
-                        memory: 64Mi
           EOF
 
           DESIRED=$(kubectl get nodes --no-headers 2>/dev/null | wc -l | tr -d ' ')

--- a/kubernetes/apps/observability/victoria-metrics/app/vmrule-infrastructure.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/vmrule-infrastructure.yaml
@@ -151,8 +151,10 @@ spec:
             component: kubernetes
 
         - alert: KubernetesPodOOMKilled
+          # Exclude the transient image-pull DaemonSet pods (image-pull.yaml workflow):
+          # they fail to start by design, so their churn is not a real fault.
           expr: |-
-            increase(kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}[10m]) > 0
+            increase(kube_pod_container_status_last_terminated_reason{reason="OOMKilled", pod!~"image-pull-.+"}[10m]) > 0
           keep_firing_for: 5m
           annotations:
             summary: "Pod {{ $labels.namespace }}/{{ $labels.pod }} was OOM killed"
@@ -165,8 +167,11 @@ spec:
             component: kubernetes
 
         - alert: KubernetesPodCrashLooping
+          # Exclude the transient image-pull DaemonSet pods (image-pull.yaml workflow):
+          # DaemonSet restartPolicy is always Always, so their fast-fail prepull container
+          # restarts by design until the workflow tears the DaemonSet down.
           expr: |-
-            rate(kube_pod_container_status_restarts_total[15m]) > 0.1
+            rate(kube_pod_container_status_restarts_total{pod!~"image-pull-.+"}[15m]) > 0.1
           for: 5m
           keep_firing_for: 5m
           annotations:


### PR DESCRIPTION
## What & why

A `KubernetesPodOOMKilled` page fired for `actions-runner-system/image-pull-f955e2643e11-*` (container `prepull`). Root cause: the image-pull workflow proves a pull by **running the real image entrypoint** under a 64Mi cap and treating the resulting OOMKill/crash as success.

That's the wrong inner loop:
- It executes arbitrary app code on **every node, including control-plane** (the DaemonSet tolerates all taints), as a side effect of "pull this image".
- It uses crashes as a correctness signal and **manufactures OOMKills**, which trip `KubernetesPodOOMKilled` — paging on a pod that was *designed* to die.

The workflow comment justified not overriding `command` as "distroless-safe (no shell)". But you don't need a shell: **kubelet pulls the image before it execs the container command**, so a guaranteed-nonexistent command path makes the pull happen while the container fails to start instantly (`StartError`) — the entrypoint never runs.

## Changes

**`.github/workflows/image-pull.yaml`**
- `prepull` container now overrides `command: ["/__prepull_noop_does_not_exist__"]`. Image still gets pulled; exec fails fast with `StartError`; no entrypoint runs anywhere; nothing to OOM.
- Dropped the `memory: 64Mi` limit (nothing runs, so nothing to cap). `requests` kept for scheduling.
- `warm-detection` is unchanged — it already counts `StartError`/`RunContainerError`/`Error` as "image present", so this is detection-compatible.

**`kubernetes/apps/observability/victoria-metrics/app/vmrule-infrastructure.yaml`**
- DaemonSet pods are `restartPolicy: Always`, so the fast-fail prepull container still restarts until the workflow tears the DaemonSet down. Excluded `image-pull-.+` pods from both `KubernetesPodOOMKilled` and `KubernetesPodCrashLooping` via `pod!~"image-pull-.+"`. Real OOMs/crashloops in `actions-runner-system` (and everywhere else) still alert.

## Verification
- Both files pass `yaml.safe_load`.
- Pull-before-exec confirmed in the actual incident events: `Pulled` fired, then `Created`/`Started`, then OOM — so overriding `command` does not affect the pull.