### PR TITLE
fix(rook-ceph): restore cephfs ms_mode=prefer-crc kernel mount option (fixes netbox VolSync)

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/csi/driver-cephfs.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi/driver-cephfs.yaml
@@ -1,0 +1,34 @@
+---
+# Restore the cephfs kernel mount option that Rook v1.19.6 set via the operator
+# chart value `csi.cephFSKernelMountOptions: ms_mode=prefer-crc`. That value no
+# longer exists in the Rook v1.20 operator chart, so on upgrade (PR #1170) the
+# live cephfs Driver CR was left with an EMPTY kernelMountOptions. Without it the
+# kernel cephfs client cannot negotiate msgr2 to the MDS and mounts fail with
+# "mount error: no mds (Metadata Server) is up" — even though the MDS is healthy.
+# Only CephFS-backed apps (netbox's VolSync mover) are affected; RBD is not.
+#
+# This is a MINIMAL, field-scoped manifest. The Driver CR is otherwise reconciled
+# by the in-cluster ceph-csi-operator (field manager `rook`), which writes every
+# other spec field (controllerPlugin/nodePlugin/imageSet/...). Flux applies this
+# server-side and takes ownership of ONLY .spec.kernelMountOptions; SSA leaves all
+# operator-owned fields intact (it never prunes fields owned by another manager).
+# There is no tug-of-war: the operator loads the Driver into memory, merges the
+# OperatorConfig defaults in-memory, and uses that to render its child Deployments/
+# DaemonSets — it does NOT write the Driver's own spec back, so it will not flap
+# against this field.
+#
+# kernelMountOptions is a map[string]string on the Driver CRD (csi.ceph.io/v1).
+# The operator serialises it as `key=value,key=value` and passes
+# `--kernelmountoptions=ms_mode=prefer-crc` to the cephfs nodeplugin, exactly
+# restoring the v1.19.6 behaviour.
+#
+# The name MUST be the full valid driver name `rook-ceph.cephfs.csi.ceph.com`;
+# the CRD CEL requires `.metadata.name` to match
+# `[<prefix>.](rbd|cephfs|nfs|nvmeof).csi.ceph.com`.
+apiVersion: csi.ceph.io/v1
+kind: Driver
+metadata:
+  name: rook-ceph.cephfs.csi.ceph.com
+spec:
+  kernelMountOptions:
+    ms_mode: prefer-crc

--- a/kubernetes/apps/rook-ceph/rook-ceph/csi/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./rbac.yaml
+  - ./driver-cephfs.yaml


### PR DESCRIPTION
## Problem

Follow-up to #1178. CSI is healthy and 16/17 VolSync backups recovered, but **netbox** (the only CephFS-backed VolSync app) is still stuck — its backup mover's cephfs kernel mount fails with `mount error: no mds (Metadata Server) is up`, despite a healthy MDS (CephFilesystem Ready, ACTIVEMDS=1, both mds pods Running).

**Root cause:** Rook v1.20 (#1170) dropped the operator-chart value `csi.cephFSKernelMountOptions: ms_mode=prefer-crc` — the key no longer exists in the v1.20 operator chart. The live cephfs Driver CR `rook-ceph.cephfs.csi.ceph.com` was left with an **empty** `kernelMountOptions`, so the kernel cephfs client cannot negotiate msgr2 to the MDS. RBD apps use a different mount path and are unaffected — which is why only netbox is stuck. Under v1.19.6 this option was set and cephfs mounts worked.

## Fix

Set `spec.kernelMountOptions: {ms_mode: prefer-crc}` on the cephfs Driver CR declaratively via Flux, using a **minimal, field-scoped** manifest in the existing `csi/` component.

> Note: on the `csi.ceph.io/v1` Driver CRD, `kernelMountOptions` is a `map[string]string` (not the old flat string). The ceph-csi-operator serialises it as `key=value,key=value` and passes `--kernelmountoptions=ms_mode=prefer-crc` to the cephfs nodeplugin — exactly restoring v1.19.6 behaviour.

## Why this approach (minimal SSA, Option A)

The Driver CR is reconciled by the in-cluster ceph-csi-operator (sole spec field manager: `rook`). A minimal manifest setting only `spec.kernelMountOptions` relies on Flux server-side-apply field-level ownership:

- Flux owns **only** that one field; every operator-set field (`controllerPlugin`, `nodePlugin`, `imageSet`, `cephFsClientType`, ...) keeps field manager `rook` and is preserved. SSA never prunes fields owned by another manager.
- **No tug-of-war:** the operator loads the Driver into memory, merges OperatorConfig defaults *in-memory*, and renders its child Deployments/DaemonSets from that — it does not write the Driver's own spec back. `mergeDriverSpecs` only fills `KernelMountOptions` from defaults when it is `nil`, so it will not fight our value.

## Proof — server-side dry-run merges, removes nothing

```
$ kubectl diff --server-side --field-manager=kustomize-controller -n rook-ceph -f csi/driver-cephfs.yaml
@@ metadata @@
-  generation: 1
+  generation: 2
@@ spec @@
   imageSet:
     name: rook-csi-operator-image-set-configmap
+  kernelMountOptions:
+    ms_mode: prefer-crc
   log: {}
```

Pure add of `kernelMountOptions`; zero removals. A plain `kubectl apply --server-side --dry-run=server` (no `--force-conflicts`) returns `serverside-applied` with **no conflict**, and the full valid name `rook-ceph.cephfs.csi.ceph.com` passes the CRD CEL (the short-name issue that broke #1178's first attempt is avoided).

## Residual risk

The cephfs **nodeplugin DaemonSet** likely needs to roll after the operator picks up the change before netbox's mount succeeds — the `--kernelmountoptions` arg is set at nodeplugin pod start. The operator should re-render the DaemonSet on the Driver generation bump, but a manual `kubectl -n rook-ceph rollout restart ds/<cephfs-nodeplugin>` may be needed post-merge. **Flagging for manual handling post-merge.**

DO NOT MERGE yet.