### PR TITLE
feat(rook-ceph): adopt ceph-csi-drivers chart (v1.20 proper CSI model) — PR 1/2 adopt

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrelease.yaml
@@ -1,0 +1,100 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schema.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ceph-csi-drivers
+spec:
+  interval: 1h
+  timeout: 15m
+  chart:
+    spec:
+      chart: ceph-csi-drivers
+      version: 1.0.1
+      sourceRef:
+        kind: HelmRepository
+        name: ceph-csi-operator
+        namespace: rook-ceph
+  install:
+    cleanupOnFail: false
+  upgrade:
+    cleanupOnFail: false
+  # Rook v1.20 moved CSI plugin RBAC + OperatorConfig/Driver CRs out of the rook-ceph
+  # operator chart into this ceph-csi-drivers chart. The live OperatorConfig +
+  # rook-ceph.{rbd,cephfs}.csi.ceph.com Driver CRs are pre-stamped with this release's
+  # helm metadata, so this chart ADOPTS them and creates the plugin ServiceAccounts/RBAC.
+  #
+  # Values reproduce the live (working) Driver/OperatorConfig spec to avoid any regression
+  # (full driver-name prefix per Rook convention, hostNetwork, fsGroupPolicy=File, kernel
+  # client, Recreate strategy, 2 replicas), plus the cephfs ms_mode=prefer-crc mount option.
+  # Custom CSI images stay in the rook-ceph chart (rook-csi-operator-image-set-configmap),
+  # which this chart only references.
+  values:
+    operatorConfig:
+      namespace: rook-ceph
+      driverSpecDefaults:
+        clusterName: rook-ceph
+        imageSet:
+          name: rook-csi-operator-image-set-configmap
+        cephFsClientType: kernel
+        fsGroupPolicy: File
+        deployCsiAddons: false
+        enableMetadata: false
+        generateOMapInfo: false
+        controllerPlugin:
+          hostNetwork: true
+          replicas: 2
+          deploymentStrategy:
+            type: Recreate
+          priorityClassName: system-cluster-critical
+          imagePullPolicy: IfNotPresent
+        nodePlugin:
+          kubeletDirPath: /var/lib/kubelet
+          enableSeLinuxHostMount: false
+          priorityClassName: system-node-critical
+          imagePullPolicy: IfNotPresent
+    drivers:
+      rbd:
+        enabled: true
+        name: rook-ceph.rbd.csi.ceph.com
+        # Explicit volumeSnapshot keeps the csi-snapshotter sidecar deployed (chart default
+        # "none" would remove it and break all RBD VolSync backups).
+        snapshotPolicy: volumeSnapshot
+        fsGroupPolicy: File
+        cephFsClientType: kernel
+        controllerPlugin:
+          hostNetwork: true
+          replicas: 2
+          deploymentStrategy:
+            type: Recreate
+          priorityClassName: system-cluster-critical
+          imagePullPolicy: IfNotPresent
+        nodePlugin:
+          kubeletDirPath: /var/lib/kubelet
+          enableSeLinuxHostMount: false
+          priorityClassName: system-node-critical
+          imagePullPolicy: IfNotPresent
+      cephfs:
+        enabled: true
+        name: rook-ceph.cephfs.csi.ceph.com
+        fsGroupPolicy: File
+        snapshotPolicy: volumeGroupSnapshot
+        cephFsClientType: kernel
+        kernelMountOptions:
+          ms_mode: prefer-crc
+        controllerPlugin:
+          hostNetwork: true
+          replicas: 2
+          deploymentStrategy:
+            type: Recreate
+          priorityClassName: system-cluster-critical
+          imagePullPolicy: IfNotPresent
+        nodePlugin:
+          kubeletDirPath: /var/lib/kubelet
+          enableSeLinuxHostMount: false
+          priorityClassName: system-node-critical
+          imagePullPolicy: IfNotPresent
+      nfs:
+        enabled: false
+      nvmeof:
+        enabled: false

--- a/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrepository.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schema.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: ceph-csi-operator
+spec:
+  interval: 1h
+  # The ceph-csi-drivers chart is published only to this HTTP Helm repo (index.yaml + .tgz),
+  # not as an OCI artifact (unlike the rook-ceph operator/cluster charts).
+  url: https://ceph.github.io/ceph-csi-operator

--- a/kubernetes/apps/rook-ceph/rook-ceph/csi/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi/kustomization.yaml
@@ -3,5 +3,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  # PR-1: ceph-csi-drivers chart adopts the OperatorConfig + Driver CRs and creates the
+  # plugin ServiceAccounts/RBAC. The vendored rbac.yaml + driver-cephfs.yaml bandaids are
+  # kept here only until adoption is confirmed, then removed in the follow-up PR.
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml
   - ./rbac.yaml
   - ./driver-cephfs.yaml


### PR DESCRIPTION
## Why
Rook v1.20 (#1170) moved CSI plugin RBAC + OperatorConfig/Driver CRs out of the rook-ceph operator chart into the **new required `ceph-csi-drivers` chart**. We currently work around the gap with two bandaids (`csi/rbac.yaml` vendored short-name SAs, `csi/driver-cephfs.yaml` one-field Flux patch). This replaces them with the canonical chart so CSI is fully chart/GitOps-managed and upgrade-safe.

## This PR (1 of 2 — adopt)
- Add HTTP `HelmRepository` `ceph-csi-operator` + `ceph-csi-drivers` HelmRelease (release name `ceph-csi-drivers`, ns `rook-ceph`).
- The live `OperatorConfig` + both `Driver` CRs are pre-stamped with `meta.helm.sh/release-name: ceph-csi-drivers` → Helm **adopts** them; the chart **creates** the full-name plugin SAs/RBAC and sets `serviceAccountName` on the Drivers, so the operator rolls the CSI workloads onto them (short→full SA names; existing mounts unaffected, brief provisioning pause).
- The vendored `rbac.yaml` + `driver-cephfs.yaml` stay until adoption is confirmed live, then are removed in **PR 2/2**.

## No-regression proof (server-side diff vs live, as `helm-controller`)
Values reproduce the live working spec:
- `controllerPlugin.hostNetwork: true` (chart default is `false`)
- `fsGroupPolicy: File` (chart default for cephfs is `None`)
- cephfs `snapshotPolicy: volumeGroupSnapshot` + `kernelMountOptions: {ms_mode: prefer-crc}` (the netbox cephfs fix, now chart-managed)
- **rbd `snapshotPolicy: volumeSnapshot`** — chart default `none` would remove the `csi-snapshotter` sidecar and break all RBD VolSync backups
- `Recreate` strategy, 2 replicas, kernel client, references `rook-csi-operator-image-set-configmap`

The only other diffs are the chart making implicit defaults explicit (`enableFencing: false`, `grpcTimeout: 30`, log rotation) — no behavioral change. `--force-conflicts` succeeds → helm-controller cleanly takes field ownership from the `rook` manager.

## Safety
- The live cephfs Driver has been annotated `kustomize.toolkit.fluxcd.io/prune: disabled` so the PR 2/2 file removal can't trigger a Flux GC delete of it.
- CRDs are NOT rendered by this chart (managed by the rook-ceph operator subchart) — no conflict.