### PR TITLE
fix(rook-ceph): drop invalid HelmRelease spec.install.cleanupOnFail

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrelease.yaml
@@ -15,8 +15,6 @@ spec:
         kind: HelmRepository
         name: ceph-csi-operator
         namespace: rook-ceph
-  install:
-    cleanupOnFail: false
   upgrade:
     cleanupOnFail: false
   # Rook v1.20 moved CSI plugin RBAC + OperatorConfig/Driver CRs out of the rook-ceph


### PR DESCRIPTION
Follow-up to #1181. `cleanupOnFail` is only valid under `spec.upgrade`, not `spec.install` — the live HelmRelease CRD rejected it ('field not declared in schema'), which aborted the `rook-ceph-csi` kustomization apply so the `ceph-csi-drivers` HelmRelease + HelmRepository were never created (CSI unaffected, still on existing resources). flux-local CI didn't catch the field. This removes the invalid `install` block.