### PR TITLE
feat(observability): scrape etcd, controller-manager and scheduler metrics

### DIFF
--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -55,13 +55,6 @@ spec:
     defaultRules:
       create: true
       groups:
-        # Disable rules for components we don't use
-        etcd:
-          create: false
-        kubernetesSystemControllerManager:
-          create: false
-        kubernetesSystemScheduler:
-          create: false
         # Disable Alertmanager cluster rules (we run single replica)
         alertmanager:
           create: false
@@ -483,13 +476,43 @@ spec:
           spec:
             path: /metrics/resource
 
-    # Disable scraping for components we don't have
-    kubeControllerManager:
-      enabled: false
+    # Control-plane component scraping (kubeadm exposes all three)
+    # etcd serves plain HTTP metrics on 2381 (--listen-metrics-urls)
     kubeEtcd:
-      enabled: false
+      enabled: true
+      service:
+        port: 2381
+        targetPort: 2381
+      vmScrape:
+        spec:
+          jobLabel: app.kubernetes.io/component
+          endpoints:
+            - port: http-metrics
+              scheme: http
+    # CM/scheduler use self-signed serving certs, so skip TLS verification
+    kubeControllerManager:
+      enabled: true
+      vmScrape:
+        spec:
+          jobLabel: app.kubernetes.io/component
+          endpoints:
+            - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+              port: http-metrics
+              scheme: https
+              tlsConfig:
+                insecureSkipVerify: true
     kubeScheduler:
-      enabled: false
+      enabled: true
+      vmScrape:
+        spec:
+          jobLabel: app.kubernetes.io/component
+          endpoints:
+            - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+              port: http-metrics
+              scheme: https
+              tlsConfig:
+                insecureSkipVerify: true
+    # kube-proxy not deployed (Cilium kube-proxy replacement)
     kubeProxy:
       enabled: false
 


### PR DESCRIPTION
## What
Enable Victoria Metrics k8s-stack scraping for the three control-plane components that were disabled in the Talos era, plus their default alert rule groups.

## Why
The Flatcar/kubeadm control plane already exposes all three:
- **etcd**: plain HTTP `:2381` (`--listen-metrics-urls=http://0.0.0.0:2381`) — verified reachable in-cluster
- **controller-manager / scheduler**: `:10257`/`:10259`, `--bind-address=0.0.0.0`, self-signed serving certs → scrape uses SA bearer token + `insecureSkipVerify`

etcd disk latency metrics (`etcd_disk_wal_fsync_duration_seconds`, `etcd_disk_backend_commit_duration_seconds`) are the baseline needed to decide on further hypervisor tuning (1G hugepages, C-state capping) for the k8s VMs.

## Validation
`helm template` against chart 0.82.0 renders the expected objects: etcd Service on 2381 selecting `component: etcd` static pods with an http-scheme VMServiceScrape; CM/scheduler scrapes with bearer token + skip-verify.