### PR TITLE
fix(observability): tune TrustSec SGACL deny alerts to spike-over-baseline

### DIFF
--- a/kubernetes/apps/observability/victoria-logs/rules/cisco-trustsec-vmrule.yaml
+++ b/kubernetes/apps/observability/victoria-logs/rules/cisco-trustsec-vmrule.yaml
@@ -13,15 +13,55 @@ spec:
       type: vlogs
       interval: 1m
       rules:
+        # Anomaly (spike-over-baseline) detection, not a per-event tripwire.
+        #
+        # SC01's RBACL_DENY_LOG SGACL logs normal inter-VLAN policy enforcement,
+        # producing a constant deny hum. The old rule (>0, for:0m) fired on any
+        # single normal deny and never cleared. It also matched action='Permit'
+        # SGACLHIT lines (the same %RBM-6-SGACLHIT message carries both Permit
+        # and Deny), inflating the count. This rule counts ONLY action='Deny'
+        # over a fixed 5m window, excludes the known-constant noise signatures,
+        # and fires only when the deny rate is ABNORMALLY high vs the measured
+        # baseline (possible scan / compromised device / misconfig flood).
+        #
+        # A 5m window (not 15m) is used so a brief one-shot flood elevates the
+        # count for only ~5m and decays, letting for:10m suppress transients.
+        # Baseline measured live 2026-06-10 over 6h (deny-only, noise excluded):
+        #   steady-state 13-32 denies / 5m (very stable, mean ~20, max 32).
+        #   A real anomaly the same day (one IoT host flooding udp/53 to the DNS
+        #   VIP and being denied) hit 362 / 5m for a single bucket, then ~26.
+        # Threshold >150 = ~4.7x the steady ceiling (32), ~59% below the observed
+        # flood (362). for:10m means a single transient 5m burst does NOT page;
+        # only a SUSTAINED flood across multiple windows fires.
+        #
+        # Excluded constant-noise signatures (working-as-intended isolation):
+        #   - FN-LINK IoT gadget 192.168.138.86 hammering the dead gateway SVI
+        #     port tcp/80 (13->32 RBACL_FROM_SWITCH_SVIS RST egress).
+        #   - NetBIOS broadcasts udp/137 and udp/138.
+        #   - ICMP-unreachable within VLANs.
+        # The dominant udp/53 guest->DNS-VIP deny is deliberately NOT excluded,
+        # because that is exactly the class of flood the anomaly threshold must
+        # still catch.
         - alert: CiscoTrustSecSGACLDeny
           expr: |
-            facility:23 (_msg:~"SGACLHIT|IPACCESSLOG.*RBACL_DENY_LOG|RBACL_DENY_LOG") | stats count() denies | filter denies:>0
-          for: 0m
+            facility:23 _msg:"SGACLHIT" _msg:"action='Deny'" _time:5m
+              NOT (_msg:"192.168.138.86" _msg:"dest-port='80'")
+              NOT _msg:"dest-port='137'"
+              NOT _msg:"dest-port='138'"
+              NOT _msg:"protocol='icmp'"
+            | stats count() denies | filter denies:>150
+          for: 10m
           annotations:
-            summary: SC01 TrustSec SGACL deny observed
+            summary: SC01 TrustSec SGACL deny rate ABNORMALLY high vs baseline
             description: >-
-              SC01 emitted one or more TrustSec SGACL deny events in the last VMAlert logs evaluation window.
-              Query VictoriaLogs for facility:23 and RBACL_DENY_LOG / SGACLHIT to inspect sgt/dgt, src/dst, and ports.
+              SC01 logged {{ $value }} TrustSec SGACL DENY events in the last 5m, far above the
+              normal baseline (~13-32/5m). This is NOT the expected steady IoT/NetBIOS isolation
+              hum (which is excluded) — it indicates a possible scan, a compromised/misbehaving
+              device flooding denied flows, or a new lateral-movement attempt. Investigate before
+              dismissing. Query VictoriaLogs to find the top talker:
+              facility:23 _msg:"SGACLHIT" _msg:"action='Deny'" _time:15m
+              | extract "src-ip='<src>'" | extract "dest-port='<dport>'"
+              | stats by (src,dport) count() hits | sort by (hits desc)
             runbook_url: https://docs.victoriametrics.com/victorialogs/logsql/
           labels:
             severity: warning

--- a/kubernetes/apps/observability/victoria-metrics/app/trustsec-sgacl-exporter.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/trustsec-sgacl-exporter.yaml
@@ -253,15 +253,44 @@ spec:
           labels:
             severity: warning
             component: trustsec
+        # Anomaly (spike-over-baseline) detection, not a per-increment tripwire.
+        #
+        # SC01's RBACL_DENY_LOG SGACL drops a constant stream of inter-VLAN
+        # policy denies (IoT/NetBIOS isolation, guest->DNS-VIP, FN-LINK dead-port
+        # RST flood). The old rule (>0, for:0m) fired on ANY deny-counter
+        # increment and never cleared. This rule fires only when the 5m deny
+        # PACKET volume is abnormally high vs the measured baseline — a sudden
+        # flood of denies that suggests a scan, a compromised/misbehaving device,
+        # or a misconfig, NOT the normal steady hum.
+        #
+        # NOTE: this counter counts denied PACKETS (every packet of a denied
+        # flow, both sw+hw plane), so its scale is much larger than the
+        # rate-limited SGACLHIT log lines — it is baselined independently.
+        # A 5m increase window (not 15m) is used deliberately: it tracks the
+        # actual deny RATE sharply, so a brief one-shot flood elevates the metric
+        # for only ~5m and then decays, instead of a 15m window smearing a 2-3min
+        # flood across a full 15m (which would defeat the for:10m guard).
+        # Baseline measured live 2026-06-10 over 6h, sum(increase(denied[5m])):
+        #   steady-state 99-292 packets / 5m (mean ~158, max 292).
+        #   A real anomaly the same day (one IoT host flooding udp/53 to the DNS
+        #   VIP) hit 1529 / 5m for a single 5m bucket, then dropped back to ~120.
+        # Threshold >800 = ~2.7x the steady ceiling (292), ~5x mean, ~48% below
+        # the observed flood peak (1529). for:10m means a single transient 5m
+        # flood (elevated only ~5-9m) does NOT page; only a SUSTAINED flood
+        # spanning multiple consecutive 5m windows fires.
         - alert: TrustSecSGACLDenyCounterIncreased
           expr: |-
-            sum(increase(cisco_trustsec_sgacl_packets_total{device="sc01",action="denied"}[5m])) > 0
-          for: 0m
+            sum(increase(cisco_trustsec_sgacl_packets_total{device="sc01",action="denied"}[5m])) > 800
+          for: 10m
           keep_firing_for: 5m
           annotations:
-            summary: SC01 TrustSec SGACL deny counter increased
+            summary: SC01 TrustSec SGACL deny rate ABNORMALLY high vs baseline
             description: >-
-              One or more SC01 TrustSec SGACL deny counters increased in the last 5 minutes. Check VictoriaLogs for RBACL_DENY_LOG / SGACLHIT to identify source and destination SGT/IP/port.
+              SC01 denied {{ $value | humanize }} packets in the last 5m, far above the normal
+              baseline (~99-292/5m). This is NOT the expected steady IoT/NetBIOS isolation hum —
+              it indicates a possible scan, a compromised/misbehaving device flooding denied flows,
+              or a misconfig. Check VictoriaLogs (CiscoTrustSecSGACLDeny) for the top deny talker by
+              src-ip/dest-port/SGT before dismissing.
           labels:
             severity: warning
             component: trustsec


### PR DESCRIPTION
## What

Both SC01 TrustSec SGACL deny alerts fired **constantly by design** (`> 0`, `for: 0m`) — any single normal inter-VLAN policy deny pinned them firing forever. They are now **anomaly (spike-over-baseline) detectors** that page only on an abnormal flood of denies (possible scan / compromised device / misconfig), not the steady working-as-intended isolation hum.

Files (the two rules live in their own files, not `vmrule-network-infra.yaml`; tuned in place to avoid duplicate-alert conflicts):
- `kubernetes/apps/observability/victoria-logs/rules/cisco-trustsec-vmrule.yaml` — `CiscoTrustSecSGACLDeny`
- `kubernetes/apps/observability/victoria-metrics/app/trustsec-sgacl-exporter.yaml` — `TrustSecSGACLDenyCounterIncreased`

## CiscoTrustSecSGACLDeny (VictoriaLogs)

| | Old | New |
|--|--|--|
| expr | `SGACLHIT\|RBACL_DENY_LOG \| count > 0` | `action='Deny'` only, `_time:5m`, noise-excluded, `count > 150` |
| for | `0m` | `10m` |

- Old expr also matched `action='Permit'` SGACLHIT lines (same `%RBM-6-SGACLHIT` message carries both), inflating the count.
- Excludes known-constant noise: FN-LINK `192.168.138.86` dead-port tcp/80 RST flood, NetBIOS udp/137-138, icmp-unreachable. The dominant guest→DNS-VIP udp/53 deny is **deliberately not excluded** (it's exactly the flood class to catch).
- **Baseline measured live 2026-06-10 / 6h:** 13-32 denies/5m steady (mean ~20). A real flood (one IoT host hammering udp/53 to the DNS VIP) hit **362/5m**. Threshold **150** = ~4.7x steady ceiling (32), ~59% below the flood.

## TrustSecSGACLDenyCounterIncreased (metrics)

| | Old | New |
|--|--|--|
| expr | `sum(increase(denied[5m])) > 0` | `sum(increase(denied[5m])) > 800` |
| for | `0m` | `10m` |

- This counter counts denied **packets** (sw+hw plane), so it's baselined independently of the rate-limited log lines. 5m window keeps a one-shot flood from smearing across 15m and defeating the `for:` guard.
- **Baseline measured live 2026-06-10 / 6h:** 99-292 packets/5m steady (mean ~158). The same flood hit **1529/5m**. Threshold **800** = ~2.7x steady ceiling (292), ~48% below the flood.

## Validation (live, in-cluster)

- ✅ YAML parses; both VMRule docs valid.
- ✅ Referenced fields exist: `cisco_trustsec_sgacl_packets_total{action="denied"}` (1068 series in VM) and the `SGACLHIT`/`action='Deny'` log fields.
- ✅ Both exprs evaluate to **0 series (non-firing)** on the current steady baseline (logs 5m count = 26 vs 150; metrics increase[5m] = ~174-222 vs 800).
- ✅ `for: 10m` means a single transient 5m flood (like today's, elevated ~5m then decayed) does **not** page; only a sustained multi-window flood fires.
- ✅ Watchdog and all other rules untouched (only the two target alerts changed).

## Follow-up (NOT in this PR)

~52% of the deny noise (the FN-LINK `192.168.138.86` → gateway SVI tcp/80 RST flood) could be killed at the source with a **non-logging** deny for the 13→32 tcp/80 flow on SC01 — a network-domain change, separate from this observability tuning.