### PR TITLE
fix(observability): repair network-syslog dashboard timeseries panels

### DIFF
--- a/kubernetes/apps/observability/victoria-logs/app/network-syslog-dashboard.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/network-syslog-dashboard.yaml
@@ -19,11 +19,11 @@ data:
           "gridPos": { "h": 8, "w": 16, "x": 0, "y": 0 },
           "datasource": { "type": "victoriametrics-logs-datasource", "uid": "${DS_VICTORIALOGS}" },
           "targets": [
-            { "expr": "hostname:exact(gateway0)", "legendFormat": "gateway0", "queryType": "hits", "refId": "A" },
-            { "expr": "hostname:exact(cell-gateway0)", "legendFormat": "cell-gateway0", "queryType": "hits", "refId": "B" },
-            { "expr": "hostname:exact(cell-gateway1)", "legendFormat": "cell-gateway1", "queryType": "hits", "refId": "C" },
-            { "expr": "facility:23", "legendFormat": "cisco-sc01", "queryType": "hits", "refId": "D" },
-            { "expr": "hostname:LivingRoomAP OR hostname:LoftAP OR hostname:FlexAP", "legendFormat": "unifi-aps", "queryType": "hits", "refId": "E" }
+            { "expr": "hostname:=\"gateway0\" | stats by (_time:$__interval) count() as records", "legendFormat": "gateway0", "queryType": "statsRange", "refId": "A" },
+            { "expr": "hostname:=\"cell-gateway0\" | stats by (_time:$__interval) count() as records", "legendFormat": "cell-gateway0", "queryType": "statsRange", "refId": "B" },
+            { "expr": "hostname:=\"cell-gateway1\" | stats by (_time:$__interval) count() as records", "legendFormat": "cell-gateway1", "queryType": "statsRange", "refId": "C" },
+            { "expr": "facility:23 | stats by (_time:$__interval) count() as records", "legendFormat": "cisco-sc01", "queryType": "statsRange", "refId": "D" },
+            { "expr": "(hostname:=\"LivingRoomAP\" OR hostname:=\"LoftAP\" OR hostname:=\"FlexAP\") | stats by (_time:$__interval) count() as records", "legendFormat": "unifi-aps", "queryType": "statsRange", "refId": "E" }
           ],
           "fieldConfig": {
             "defaults": {
@@ -41,8 +41,8 @@ data:
           "gridPos": { "h": 8, "w": 8, "x": 16, "y": 0 },
           "datasource": { "type": "victoriametrics-logs-datasource", "uid": "${DS_VICTORIALOGS}" },
           "targets": [
-            { "expr": "NOT kubernetes.pod_namespace:* (severity:4 OR severity:3 OR severity:2)", "legendFormat": "warn/err/crit", "queryType": "hits", "refId": "A" },
-            { "expr": "NOT kubernetes.pod_namespace:* (severity:6 OR severity:5)", "legendFormat": "info/notice", "queryType": "hits", "refId": "B" }
+            { "expr": "(severity:4 OR severity:3 OR severity:2) -kubernetes.pod_namespace:* | stats by (_time:$__interval) count() as records", "legendFormat": "warn/err/crit", "queryType": "statsRange", "refId": "A" },
+            { "expr": "(severity:6 OR severity:5) -kubernetes.pod_namespace:* | stats by (_time:$__interval) count() as records", "legendFormat": "info/notice", "queryType": "statsRange", "refId": "B" }
           ],
           "fieldConfig": {
             "defaults": {
@@ -63,9 +63,9 @@ data:
           "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
           "datasource": { "type": "victoriametrics-logs-datasource", "uid": "${DS_VICTORIALOGS}" },
           "targets": [
-            { "expr": "app_name:kernel _msg:SRC hostname:exact(gateway0)", "legendFormat": "gateway0", "queryType": "hits", "refId": "A" },
-            { "expr": "app_name:kernel _msg:SRC hostname:exact(cell-gateway0)", "legendFormat": "cell-gateway0", "queryType": "hits", "refId": "B" },
-            { "expr": "app_name:kernel _msg:SRC hostname:exact(cell-gateway1)", "legendFormat": "cell-gateway1", "queryType": "hits", "refId": "C" }
+            { "expr": "app_name:kernel _msg:SRC hostname:=\"gateway0\" | stats by (_time:$__interval) count() as records", "legendFormat": "gateway0", "queryType": "statsRange", "refId": "A" },
+            { "expr": "app_name:kernel _msg:SRC hostname:=\"cell-gateway0\" | stats by (_time:$__interval) count() as records", "legendFormat": "cell-gateway0", "queryType": "statsRange", "refId": "B" },
+            { "expr": "app_name:kernel _msg:SRC hostname:=\"cell-gateway1\" | stats by (_time:$__interval) count() as records", "legendFormat": "cell-gateway1", "queryType": "statsRange", "refId": "C" }
           ],
           "fieldConfig": {
             "defaults": {
@@ -84,7 +84,7 @@ data:
           "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
           "datasource": { "type": "victoriametrics-logs-datasource", "uid": "${DS_VICTORIALOGS}" },
           "targets": [
-            { "expr": "facility:23 _msg:~\"IPACCESSLOGP\"", "legendFormat": "acl_denies", "queryType": "hits", "refId": "A" }
+            { "expr": "facility:23 _msg:~\"IPACCESSLOGP\" | stats by (_time:$__interval) count() as denies", "legendFormat": "acl_denies", "queryType": "statsRange", "refId": "A" }
           ],
           "fieldConfig": {
             "defaults": {
@@ -103,7 +103,7 @@ data:
           "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
           "datasource": { "type": "victoriametrics-logs-datasource", "uid": "${DS_VICTORIALOGS}" },
           "targets": [
-            { "expr": "facility:23 _msg:\"SGACLHIT\" _msg:~\"action='Deny'\"", "legendFormat": "sgacl_denies", "queryType": "hits", "refId": "A" }
+            { "expr": "facility:23 _msg:\"SGACLHIT\" _msg:~\"action='Deny'\" | stats by (_time:$__interval) count() as denies", "legendFormat": "sgacl_denies", "queryType": "statsRange", "refId": "A" }
           ],
           "fieldConfig": {
             "defaults": {
@@ -148,7 +148,7 @@ data:
           "type": "logs",
           "gridPos": { "h": 10, "w": 24, "x": 0, "y": 44 },
           "datasource": { "type": "victoriametrics-logs-datasource", "uid": "${DS_VICTORIALOGS}" },
-          "targets": [{ "expr": "(hostname:exact(gateway0) OR hostname:exact(cell-gateway0) OR hostname:exact(cell-gateway1)) NOT app_name:kernel NOT app_name:blackbox_exporter", "refId": "A" }],
+          "targets": [{ "expr": "(hostname:=\"gateway0\" OR hostname:=\"cell-gateway0\" OR hostname:=\"cell-gateway1\") NOT app_name:kernel NOT app_name:blackbox_exporter", "refId": "A" }],
           "options": { "showTime": true, "showLabels": true, "showCommonLabels": false, "wrapLogMessage": true, "enableLogDetails": true, "enableInfiniteScrolling": true, "sortOrder": "Descending" }
         },
         {
@@ -178,7 +178,7 @@ data:
       "timezone": "browser",
       "title": "Network Device Syslog",
       "uid": "network-syslog",
-      "version": 6
+      "version": 7
     }
 ---
 # yaml-language-server: $schema=https://kubernetes-schema.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json


### PR DESCRIPTION
## Problem
Every timeseries panel on the **Network Device Syslog** dashboard showed **"No data"** with red 422 errors (confirmed live in the browser).

## Root cause
The `victoriametrics-logs-datasource` plugin (v0.26.3) **no longer has a `hits` queryType** — the dashboard was authored against an older plugin version. Three syntax issues compounded it. All verified live in Grafana Explore before committing.

## Fixes
- **`queryType: "hits"` → `"statsRange"`** on all 5 timeseries panels (12 targets). The "Range" type **requires** a `| stats ...` pipe — bare filters 422 with *"missing `| stats` pipe"*.
- **Appended `| stats by (_time:$__interval) count()`** to each timeseries target.
- **`hostname:exact(X)` → `hostname:="X"`** — `exact()` is unsupported (422 *"unsupported function"*). 9 occurrences, incl. the VyOS System Logs (logs) panel.
- **Severity panels:** `NOT kubernetes.pod_namespace:* (severity:…)` only parsed the first term (422 *"unparsed data left"*) → `(severity:…) -kubernetes.pod_namespace:*`.

Logs-type panels were already working and keep their queries (just the `exact()` fix).

## Verification
Both corrected query forms (ACL denies + severity) were run live in Grafana Explore and render graphs with data. Embedded dashboard JSON re-validated.