### PR TITLE
fix(observability): quoted exact-match in syslog dashboard (statsRange rejects :=)

### DIFF
--- a/kubernetes/apps/observability/victoria-logs/app/network-syslog-dashboard.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/network-syslog-dashboard.yaml
@@ -19,11 +19,11 @@ data:
           "gridPos": { "h": 8, "w": 16, "x": 0, "y": 0 },
           "datasource": { "type": "victoriametrics-logs-datasource", "uid": "${DS_VICTORIALOGS}" },
           "targets": [
-            { "expr": "hostname:=\"gateway0\" | stats by (_time:$__interval) count() as records", "legendFormat": "gateway0", "queryType": "statsRange", "refId": "A" },
-            { "expr": "hostname:=\"cell-gateway0\" | stats by (_time:$__interval) count() as records", "legendFormat": "cell-gateway0", "queryType": "statsRange", "refId": "B" },
-            { "expr": "hostname:=\"cell-gateway1\" | stats by (_time:$__interval) count() as records", "legendFormat": "cell-gateway1", "queryType": "statsRange", "refId": "C" },
+            { "expr": "hostname:\"gateway0\" | stats by (_time:$__interval) count() as records", "legendFormat": "gateway0", "queryType": "statsRange", "refId": "A" },
+            { "expr": "hostname:\"cell-gateway0\" | stats by (_time:$__interval) count() as records", "legendFormat": "cell-gateway0", "queryType": "statsRange", "refId": "B" },
+            { "expr": "hostname:\"cell-gateway1\" | stats by (_time:$__interval) count() as records", "legendFormat": "cell-gateway1", "queryType": "statsRange", "refId": "C" },
             { "expr": "facility:23 | stats by (_time:$__interval) count() as records", "legendFormat": "cisco-sc01", "queryType": "statsRange", "refId": "D" },
-            { "expr": "(hostname:=\"LivingRoomAP\" OR hostname:=\"LoftAP\" OR hostname:=\"FlexAP\") | stats by (_time:$__interval) count() as records", "legendFormat": "unifi-aps", "queryType": "statsRange", "refId": "E" }
+            { "expr": "(hostname:\"LivingRoomAP\" OR hostname:\"LoftAP\" OR hostname:\"FlexAP\") | stats by (_time:$__interval) count() as records", "legendFormat": "unifi-aps", "queryType": "statsRange", "refId": "E" }
           ],
           "fieldConfig": {
             "defaults": {
@@ -63,9 +63,9 @@ data:
           "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
           "datasource": { "type": "victoriametrics-logs-datasource", "uid": "${DS_VICTORIALOGS}" },
           "targets": [
-            { "expr": "app_name:kernel _msg:SRC hostname:=\"gateway0\" | stats by (_time:$__interval) count() as records", "legendFormat": "gateway0", "queryType": "statsRange", "refId": "A" },
-            { "expr": "app_name:kernel _msg:SRC hostname:=\"cell-gateway0\" | stats by (_time:$__interval) count() as records", "legendFormat": "cell-gateway0", "queryType": "statsRange", "refId": "B" },
-            { "expr": "app_name:kernel _msg:SRC hostname:=\"cell-gateway1\" | stats by (_time:$__interval) count() as records", "legendFormat": "cell-gateway1", "queryType": "statsRange", "refId": "C" }
+            { "expr": "app_name:kernel _msg:SRC hostname:\"gateway0\" | stats by (_time:$__interval) count() as records", "legendFormat": "gateway0", "queryType": "statsRange", "refId": "A" },
+            { "expr": "app_name:kernel _msg:SRC hostname:\"cell-gateway0\" | stats by (_time:$__interval) count() as records", "legendFormat": "cell-gateway0", "queryType": "statsRange", "refId": "B" },
+            { "expr": "app_name:kernel _msg:SRC hostname:\"cell-gateway1\" | stats by (_time:$__interval) count() as records", "legendFormat": "cell-gateway1", "queryType": "statsRange", "refId": "C" }
           ],
           "fieldConfig": {
             "defaults": {
@@ -148,7 +148,7 @@ data:
           "type": "logs",
           "gridPos": { "h": 10, "w": 24, "x": 0, "y": 44 },
           "datasource": { "type": "victoriametrics-logs-datasource", "uid": "${DS_VICTORIALOGS}" },
-          "targets": [{ "expr": "(hostname:=\"gateway0\" OR hostname:=\"cell-gateway0\" OR hostname:=\"cell-gateway1\") NOT app_name:kernel NOT app_name:blackbox_exporter", "refId": "A" }],
+          "targets": [{ "expr": "(hostname:\"gateway0\" OR hostname:\"cell-gateway0\" OR hostname:\"cell-gateway1\") NOT app_name:kernel NOT app_name:blackbox_exporter", "refId": "A" }],
           "options": { "showTime": true, "showLabels": true, "showCommonLabels": false, "wrapLogMessage": true, "enableLogDetails": true, "enableInfiniteScrolling": true, "sortOrder": "Descending" }
         },
         {
@@ -178,7 +178,7 @@ data:
       "timezone": "browser",
       "title": "Network Device Syslog",
       "uid": "network-syslog",
-      "version": 7
+      "version": 8
     }
 ---
 # yaml-language-server: $schema=https://kubernetes-schema.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json


### PR DESCRIPTION
Follow-up to #1202. Grafana-Explore-verified that the `stats_query_range` parser rejects `field:="value"` (422 *unexpected token =*) but accepts quoted `hostname:"value"`. Replaced all 12 `hostname:=` with `hostname:"`. Verified both plain (`gateway0`) and hyphenated (`cell-gateway0`) hostnames render graphs.