### PR TITLE
fix(observability): bind syslog dashboard to VictoriaLogs datasource by UID

### DIFF
--- a/kubernetes/apps/observability/victoria-logs/app/network-syslog-dashboard.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/network-syslog-dashboard.yaml
@@ -17,7 +17,7 @@ data:
           "description": "Log ingestion rate per device over time",
           "type": "timeseries",
           "gridPos": { "h": 8, "w": 16, "x": 0, "y": 0 },
-          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "${DS_VICTORIALOGS}" },
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "99690ba1-1b0d-451b-9132-40ed366b99b9" },
           "targets": [
             { "expr": "hostname:\"gateway0\" | stats by (_time:$__interval) count() as records", "legendFormat": "gateway0", "queryType": "statsRange", "refId": "A" },
             { "expr": "hostname:\"cell-gateway0\" | stats by (_time:$__interval) count() as records", "legendFormat": "cell-gateway0", "queryType": "statsRange", "refId": "B" },
@@ -39,7 +39,7 @@ data:
           "description": "Warning/Error/Critical vs Info/Notice",
           "type": "timeseries",
           "gridPos": { "h": 8, "w": 8, "x": 16, "y": 0 },
-          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "${DS_VICTORIALOGS}" },
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "99690ba1-1b0d-451b-9132-40ed366b99b9" },
           "targets": [
             { "expr": "(severity:4 OR severity:3 OR severity:2) -kubernetes.pod_namespace:* | stats by (_time:$__interval) count() as records", "legendFormat": "warn/err/crit", "queryType": "statsRange", "refId": "A" },
             { "expr": "(severity:6 OR severity:5) -kubernetes.pod_namespace:* | stats by (_time:$__interval) count() as records", "legendFormat": "info/notice", "queryType": "statsRange", "refId": "B" }
@@ -61,7 +61,7 @@ data:
           "description": "Firewall deny/drop events across all VyOS routers",
           "type": "timeseries",
           "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
-          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "${DS_VICTORIALOGS}" },
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "99690ba1-1b0d-451b-9132-40ed366b99b9" },
           "targets": [
             { "expr": "app_name:kernel _msg:SRC hostname:\"gateway0\" | stats by (_time:$__interval) count() as records", "legendFormat": "gateway0", "queryType": "statsRange", "refId": "A" },
             { "expr": "app_name:kernel _msg:SRC hostname:\"cell-gateway0\" | stats by (_time:$__interval) count() as records", "legendFormat": "cell-gateway0", "queryType": "statsRange", "refId": "B" },
@@ -82,7 +82,7 @@ data:
           "description": "SC01 ACL deny events",
           "type": "timeseries",
           "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
-          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "${DS_VICTORIALOGS}" },
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "99690ba1-1b0d-451b-9132-40ed366b99b9" },
           "targets": [
             { "expr": "facility:23 _msg:~\"IPACCESSLOGP\" | stats by (_time:$__interval) count() as denies", "legendFormat": "acl_denies", "queryType": "statsRange", "refId": "A" }
           ],
@@ -101,7 +101,7 @@ data:
           "description": "SC01 TrustSec SGACL deny events (%RBM-6-SGACLHIT, RBACL_DENY_LOG, action='Deny'). Permit hits excluded.",
           "type": "timeseries",
           "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
-          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "${DS_VICTORIALOGS}" },
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "99690ba1-1b0d-451b-9132-40ed366b99b9" },
           "targets": [
             { "expr": "facility:23 _msg:\"SGACLHIT\" _msg:~\"action='Deny'\" | stats by (_time:$__interval) count() as denies", "legendFormat": "sgacl_denies", "queryType": "statsRange", "refId": "A" }
           ],
@@ -120,7 +120,7 @@ data:
           "description": "SC01 SGACL deny log lines. Expand rows to read sgt/dgt, src-ip/dest-ip, dest-port, protocol from _msg.",
           "type": "logs",
           "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
-          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "${DS_VICTORIALOGS}" },
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "99690ba1-1b0d-451b-9132-40ed366b99b9" },
           "targets": [{ "expr": "facility:23 _msg:\"SGACLHIT\" _msg:~\"action='Deny'\"", "refId": "A" }],
           "options": { "showTime": true, "showLabels": true, "showCommonLabels": false, "wrapLogMessage": true, "enableLogDetails": true, "enableInfiniteScrolling": true, "sortOrder": "Descending" }
         },
@@ -129,7 +129,7 @@ data:
           "description": "Cisco 9300 syslog — ACL denies, SSH, STP, interface events. Expand rows for details.",
           "type": "logs",
           "gridPos": { "h": 10, "w": 24, "x": 0, "y": 24 },
-          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "${DS_VICTORIALOGS}" },
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "99690ba1-1b0d-451b-9132-40ed366b99b9" },
           "targets": [{ "expr": "facility:23", "refId": "A" }],
           "options": { "showTime": true, "showLabels": true, "showCommonLabels": false, "wrapLogMessage": true, "enableLogDetails": true, "enableInfiniteScrolling": true, "sortOrder": "Descending" }
         },
@@ -138,7 +138,7 @@ data:
           "description": "Kernel firewall drop logs. Expand rows to see SRC, DST, PROTO, SPT, DPT fields.",
           "type": "logs",
           "gridPos": { "h": 10, "w": 24, "x": 0, "y": 34 },
-          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "${DS_VICTORIALOGS}" },
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "99690ba1-1b0d-451b-9132-40ed366b99b9" },
           "targets": [{ "expr": "app_name:kernel _msg:SRC", "refId": "A" }],
           "options": { "showTime": true, "showLabels": true, "showCommonLabels": false, "wrapLogMessage": true, "enableLogDetails": true, "enableInfiniteScrolling": true, "sortOrder": "Descending" }
         },
@@ -147,7 +147,7 @@ data:
           "description": "VyOS service, routing, DHCP, and auth logs",
           "type": "logs",
           "gridPos": { "h": 10, "w": 24, "x": 0, "y": 44 },
-          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "${DS_VICTORIALOGS}" },
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "99690ba1-1b0d-451b-9132-40ed366b99b9" },
           "targets": [{ "expr": "(hostname:\"gateway0\" OR hostname:\"cell-gateway0\" OR hostname:\"cell-gateway1\") NOT app_name:kernel NOT app_name:blackbox_exporter", "refId": "A" }],
           "options": { "showTime": true, "showLabels": true, "showCommonLabels": false, "wrapLogMessage": true, "enableLogDetails": true, "enableInfiniteScrolling": true, "sortOrder": "Descending" }
         },
@@ -156,7 +156,7 @@ data:
           "description": "Roaming, connect/disconnect, firmware. Expand rows to see cef.* fields.",
           "type": "logs",
           "gridPos": { "h": 10, "w": 24, "x": 0, "y": 54 },
-          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "${DS_VICTORIALOGS}" },
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "99690ba1-1b0d-451b-9132-40ed366b99b9" },
           "targets": [{ "expr": "app_name:CEF | copy cef.extension.msg _msg", "refId": "A" }],
           "options": { "showTime": true, "showLabels": true, "showCommonLabels": false, "wrapLogMessage": true, "enableLogDetails": true, "enableInfiniteScrolling": true, "sortOrder": "Descending" }
         },
@@ -165,7 +165,7 @@ data:
           "description": "AP kernel and system logs (DHCP, roaming, wireless)",
           "type": "logs",
           "gridPos": { "h": 10, "w": 24, "x": 0, "y": 64 },
-          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "${DS_VICTORIALOGS}" },
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "99690ba1-1b0d-451b-9132-40ed366b99b9" },
           "targets": [{ "expr": "hostname:LivingRoomAP OR hostname:LoftAP OR hostname:FlexAP", "refId": "A" }],
           "options": { "showTime": true, "showLabels": true, "showCommonLabels": false, "wrapLogMessage": true, "enableLogDetails": true, "enableInfiniteScrolling": true, "sortOrder": "Descending" }
         }
@@ -178,7 +178,7 @@ data:
       "timezone": "browser",
       "title": "Network Device Syslog",
       "uid": "network-syslog",
-      "version": 8
+      "version": 9
     }
 ---
 # yaml-language-server: $schema=https://kubernetes-schema.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
@@ -192,9 +192,6 @@ spec:
   instanceSelector:
     matchLabels:
       grafana.internal/instance: grafana
-  datasources:
-    - datasourceName: VictoriaLogs
-      inputName: DS_VICTORIALOGS
   configMapRef:
     name: network-syslog-dashboard
     key: network-syslog.json


### PR DESCRIPTION
## THE root cause
The syslog dashboard panels showed **No data** because the `${DS_VICTORIALOGS}` datasource variable **never resolved** — every panel fell back to the **default Prometheus/VictoriaMetrics** datasource. LogsQL sent to VictoriaMetrics produced the misleading `unsupported function` / `unparsed data` / `cannot recognize | stats` errors. (Metrics dashboards are unaffected because their fallback default *is* prometheus.)

**Confirmed live in the Grafana panel editor:** switching a panel's datasource to VictoriaLogs makes the identical queries render graphs.

## Fix
- Replace `${DS_VICTORIALOGS}` with the stable operator-assigned VictoriaLogs UID on all 11 panels
- Remove the now-unused `spec.datasources` input mapping

Query syntax (statsRange + `| stats` pipe + quoted `hostname:"x"`) was verified correct against VictoriaLogs in the panel editor (#1202/#1203).