### PR TITLE
homeops-cli: security/UX arc #19 + provider-architecture arc #20

### DIFF
--- a/cmd/homeops-cli/COMMANDS_NEW.md
+++ b/cmd/homeops-cli/COMMANDS_NEW.md
@@ -1,5 +1,0 @@
-# Deprecated
-
-Command documentation has been consolidated into [`COMMANDS.md`](./COMMANDS.md).
-
-Use that file as the canonical command reference for `homeops-cli`.

--- a/cmd/homeops-cli/cmd/bootstrap/bootstrap.go
+++ b/cmd/homeops-cli/cmd/bootstrap/bootstrap.go
@@ -15,6 +15,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"homeops-cli/internal/common"
@@ -169,16 +170,25 @@ var (
 	bootstrapKubeconfigMaxWait             = time.Duration(constants.BootstrapKubeconfigMaxWait) * time.Second
 	bootstrapCRDMaxWait                    = time.Duration(constants.BootstrapCRDMaxWait) * time.Second
 	bootstrapTalosTempDir        string
-	bootstrapPreflightChecks     = []func(*BootstrapConfig, *common.ColorLogger) *PreflightResult{
-		checkToolAvailability,
-		checkEnvironmentFiles,
-		checkNetworkConnectivity,
-		checkDNSResolution,
-		check1PasswordAuthPreflight,
-		checkMachineConfigRendering,
-		checkTalosNodes,
+	bootstrapPreflightChecks     = []preflightCheck{
+		{fn: checkToolAvailability},
+		{fn: checkEnvironmentFiles},
+		{fn: checkNetworkConnectivity},
+		{fn: checkDNSResolution},
+		// Serial: may launch an interactive `op signin`.
+		{fn: check1PasswordAuthPreflight, serial: true},
+		// Serial: resolves op:// references, so it needs the auth check first.
+		{fn: checkMachineConfigRendering, serial: true},
+		{fn: checkTalosNodes},
 	}
 )
+
+// preflightCheck pairs a check with its scheduling constraint: independent
+// checks run concurrently, serial ones run in order afterwards.
+type preflightCheck struct {
+	fn     func(*BootstrapConfig, *common.ColorLogger) *PreflightResult
+	serial bool
+}
 
 func parseReplicaCount(value string) (int, error) {
 	value = strings.TrimSpace(value)
@@ -890,9 +900,31 @@ func validatePrerequisites(config *BootstrapConfig) error {
 }
 
 func runPreflightChecks(config *BootstrapConfig, logger *common.ColorLogger) error {
+	// Independent checks run concurrently (network/DNS timeouts no longer
+	// add up); serial checks run in declaration order afterwards because they
+	// can prompt for input or depend on an earlier check.
+	results := make([]*PreflightResult, len(bootstrapPreflightChecks))
+	var wg sync.WaitGroup
+	for i, check := range bootstrapPreflightChecks {
+		if check.serial {
+			continue
+		}
+		wg.Add(1)
+		go func(i int, fn func(*BootstrapConfig, *common.ColorLogger) *PreflightResult) {
+			defer wg.Done()
+			results[i] = fn(config, logger)
+		}(i, check.fn)
+	}
+	wg.Wait()
+
+	for i, check := range bootstrapPreflightChecks {
+		if check.serial {
+			results[i] = check.fn(config, logger)
+		}
+	}
+
 	var failures []string
-	for _, check := range bootstrapPreflightChecks {
-		result := check(config, logger)
+	for _, result := range results {
 		switch result.Status {
 		case "PASS":
 			logger.Success("✓ %s: %s", result.Name, result.Message)

--- a/cmd/homeops-cli/cmd/bootstrap/bootstrap.go
+++ b/cmd/homeops-cli/cmd/bootstrap/bootstrap.go
@@ -2853,6 +2853,7 @@ func testDynamicValuesTemplate(config *BootstrapConfig, logger *common.ColorLogg
 
 	// Create metrics collector
 	metricsCollector := metrics.NewPerformanceCollector()
+	defer metricsCollector.LogReport(logger)
 
 	// Test releases to verify template works
 	testReleases := []string{"cilium", "coredns", "spegel", "cert-manager", "external-secrets", "flux-operator", "flux-instance"}

--- a/cmd/homeops-cli/cmd/bootstrap/bootstrap_flow_test.go
+++ b/cmd/homeops-cli/cmd/bootstrap/bootstrap_flow_test.go
@@ -147,16 +147,16 @@ func TestRunPreflightChecksUsesInjectedChecks(t *testing.T) {
 	oldPreflightChecks := bootstrapPreflightChecks
 	t.Cleanup(func() { bootstrapPreflightChecks = oldPreflightChecks })
 
-	bootstrapPreflightChecks = []func(*BootstrapConfig, *common.ColorLogger) *PreflightResult{
-		func(*BootstrapConfig, *common.ColorLogger) *PreflightResult {
+	bootstrapPreflightChecks = []preflightCheck{
+		{fn: func(*BootstrapConfig, *common.ColorLogger) *PreflightResult {
 			return &PreflightResult{Name: "tools", Status: "PASS", Message: "ok"}
-		},
-		func(*BootstrapConfig, *common.ColorLogger) *PreflightResult {
+		}},
+		{fn: func(*BootstrapConfig, *common.ColorLogger) *PreflightResult {
 			return &PreflightResult{Name: "network", Status: "WARN", Message: "slow"}
-		},
-		func(*BootstrapConfig, *common.ColorLogger) *PreflightResult {
+		}},
+		{fn: func(*BootstrapConfig, *common.ColorLogger) *PreflightResult {
 			return &PreflightResult{Name: "talos", Status: "FAIL", Message: "missing nodes"}
-		},
+		}, serial: true},
 	}
 
 	err := runPreflightChecks(&BootstrapConfig{}, common.NewColorLogger())

--- a/cmd/homeops-cli/cmd/talos/talos.go
+++ b/cmd/homeops-cli/cmd/talos/talos.go
@@ -407,7 +407,7 @@ func withVSphereClient(logger *common.ColorLogger, fn func(vsphereClient) error)
 		return err
 	}
 
-	client := newVSphereClientFn(host, username, password, true)
+	client := newVSphereClientFn(host, username, password, common.EnvBool(constants.EnvVSphereInsecure, false))
 	if err := client.Connect(host, username, password, common.EnvBool(constants.EnvVSphereInsecure, false)); err != nil {
 		return fmt.Errorf("failed to connect to vSphere: %w", err)
 	}

--- a/cmd/homeops-cli/cmd/talos/talos.go
+++ b/cmd/homeops-cli/cmd/talos/talos.go
@@ -20,6 +20,7 @@ import (
 	"homeops-cli/internal/iso"
 	"homeops-cli/internal/metrics"
 	"homeops-cli/internal/proxmox"
+	vmprov "homeops-cli/internal/provider"
 	"homeops-cli/internal/ssh"
 	"homeops-cli/internal/talos"
 	"homeops-cli/internal/templates"
@@ -91,18 +92,7 @@ var (
 	}
 	pushKubeconfigTo1PasswordFn        = common.PushKubeconfigTo1Password
 	pullKubeconfigFrom1PasswordFn      = common.PullKubeconfigFrom1Password
-	startTrueNASVMFn                   = startVM
-	stopTrueNASVMFn                    = stopVM
-	infoTrueNASVMFn                    = infoVM
-	deleteTrueNASVMFn                  = deleteVM
-	startProxmoxVMFn                   = startVMOnProxmox
-	stopProxmoxVMFn                    = stopVMOnProxmox
-	infoProxmoxVMFn                    = infoVMOnProxmox
-	deleteProxmoxVMFn                  = deleteVMOnProxmox
-	powerOnVSphereVMFn                 = powerOnVMOnVSphere
-	powerOffVSphereVMFn                = powerOffVMOnVSphere
-	infoVSphereVMFn                    = infoVMOnVSphere
-	deleteVSphereVMFn                  = deleteVMOnVSphere
+	newVMLifecycleFn                   = newVMLifecycle
 	prepareISOForTrueNASFn             = prepareISOForTrueNAS
 	prepareISOForProxmoxFn             = prepareISOForProxmox
 	prepareISOForVSphereFn             = prepareISOForVSphere
@@ -124,6 +114,9 @@ var (
 	}
 	newVSphereClientFn = func(host, username, password string, insecure bool) vsphereClient {
 		return vsphere.NewClient(host, username, password, insecure)
+	}
+	newVSphereVMManagerFn = func(host, username, password string, insecure bool) (vmprov.VMLifecycle, error) {
+		return vsphere.NewVMManager(host, username, password, insecure)
 	}
 	newTalosFactoryClientFn = func() talosFactoryClient {
 		return talos.NewFactoryClient()
@@ -418,6 +411,98 @@ func withVSphereClient(logger *common.ColorLogger, fn func(vsphereClient) error)
 	}()
 
 	return fn(client)
+}
+
+// truenasLifecycleAdapter narrows the TrueNAS manager to the shared
+// provider.VMLifecycle contract. TrueNAS deletion takes storage options;
+// they are fixed at construction because the CLI runs one lifecycle
+// operation per invocation.
+type truenasLifecycleAdapter struct {
+	trueNASVMManager
+	deleteZVols bool
+	storagePool string
+}
+
+func (a truenasLifecycleAdapter) DeleteVM(name string) error {
+	return a.trueNASVMManager.DeleteVM(name, a.deleteZVols, a.storagePool)
+}
+
+var _ vmprov.VMLifecycle = truenasLifecycleAdapter{}
+
+// newVMLifecycle builds the lifecycle implementation for a normalized
+// provider name. All VM lifecycle dispatch (list/start/stop/info/delete/
+// poweron/poweroff) funnels through here instead of per-action switches.
+func newVMLifecycle(normalizedProvider string) (vmprov.VMLifecycle, error) {
+	switch normalizedProvider {
+	case "truenas":
+		host, apiKey, err := getTrueNASCredentialsFn()
+		if err != nil {
+			return nil, err
+		}
+		vmManager := newTrueNASVMManagerFn(host, apiKey, 443, true)
+		if err := vmManager.Connect(); err != nil {
+			return nil, fmt.Errorf("failed to connect to TrueNAS: %w", err)
+		}
+		return truenasLifecycleAdapter{
+			trueNASVMManager: vmManager,
+			deleteZVols:      true,
+			storagePool:      getEnvOrDefault("STORAGE_POOL", "flashstor"),
+		}, nil
+	case "proxmox":
+		host, tokenID, secret, nodeName, err := getProxmoxCredentialsFn()
+		if err != nil {
+			return nil, err
+		}
+		vmManager, err := newProxmoxVMManagerFn(host, tokenID, secret, nodeName, common.EnvBool(constants.EnvProxmoxInsecure, false))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Proxmox VM manager: %w", err)
+		}
+		return vmManager, nil
+	case "vsphere":
+		host, username, password, err := getVSphereCredsFn()
+		if err != nil {
+			return nil, err
+		}
+		return newVSphereVMManagerFn(host, username, password, common.EnvBool(constants.EnvVSphereInsecure, false))
+	}
+	return nil, fmt.Errorf("unsupported provider: %s", normalizedProvider)
+}
+
+// withVMLifecycle runs fn against a freshly constructed provider lifecycle
+// and always closes it afterwards.
+func withVMLifecycle(normalizedProvider string, fn func(vmprov.VMLifecycle) error) error {
+	lifecycle, err := newVMLifecycleFn(normalizedProvider)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := lifecycle.Close(); closeErr != nil {
+			common.NewColorLogger().Warn("Failed to close VM manager: %v", closeErr)
+		}
+	}()
+	return fn(lifecycle)
+}
+
+// runVMLifecycleAction normalizes the provider, resolves the VM name
+// (prompting interactively when not given), then runs op against the
+// provider's lifecycle implementation.
+func runVMLifecycleAction(name, providerName, action string, op func(vmprov.VMLifecycle, string) error) error {
+	normalizedProvider, err := normalizeVMProvider(providerName)
+	if err != nil {
+		return err
+	}
+
+	name, err = chooseVMNameForProvider(name, normalizedProvider, action)
+	if err != nil {
+		return err
+	}
+	if name == "" {
+		return nil
+	}
+
+	return withVMLifecycle(normalizedProvider, func(lifecycle vmprov.VMLifecycle) error {
+		return op(lifecycle, name)
+	})
 }
 
 type talosConfigInfo struct {
@@ -802,6 +887,7 @@ func renderMachineConfigFromEmbedded(baseTemplate, patchTemplate string) ([]byte
 func renderMachineConfigFromEmbeddedWithSchematic(baseTemplate, patchTemplate, schematicID string) ([]byte, error) {
 	logger := common.NewColorLogger()
 	metricsCollector := metrics.NewPerformanceCollector()
+	defer metricsCollector.LogReport(logger)
 
 	// Create unified template renderer
 	renderer := templates.NewTemplateRenderer(common.GetWorkingDirectory(), logger, metricsCollector)
@@ -866,8 +952,9 @@ func upgradeNode(nodeIP, mode string) error {
 	}
 
 	// Extract factory image using Go YAML processor
-	metrics := metrics.NewPerformanceCollector()
-	processor := localyaml.NewProcessor(nil, metrics)
+	metricsCollector := metrics.NewPerformanceCollector()
+	defer metricsCollector.LogReport(common.NewColorLogger())
+	processor := localyaml.NewProcessor(nil, metricsCollector)
 
 	// Parse YAML content into a map
 	configData, err := processor.ParseString(string(configOutput))
@@ -2652,38 +2739,9 @@ func listVMs(provider string) error {
 		return err
 	}
 
-	logger := common.NewColorLogger()
-
-	switch normalizedProvider {
-	case "truenas":
-		return withTrueNASVMManager(logger, func(vmManager trueNASVMManager) error {
-			return vmManager.ListVMs()
-		})
-
-	case "proxmox":
-		return withProxmoxVMManager(logger, func(vmManager proxmoxVMManager) error {
-			return vmManager.ListVMs()
-		})
-
-	case "vsphere":
-		return withVSphereClient(logger, func(client vsphereClient) error {
-			vms, err := client.ListVMs()
-			if err != nil {
-				return fmt.Errorf("failed to list VMs: %w", err)
-			}
-
-			fmt.Println("\nVMs on vSphere:")
-			fmt.Println("================")
-			for _, vm := range vms {
-				fmt.Printf("- %s\n", vm.Name())
-			}
-			fmt.Printf("\nTotal: %d VMs\n", len(vms))
-
-			return nil
-		})
-	}
-
-	return nil
+	return withVMLifecycle(normalizedProvider, func(lifecycle vmprov.VMLifecycle) error {
+		return lifecycle.ListVMs()
+	})
 }
 
 func newStartVMCommand() *cobra.Command {
@@ -2715,121 +2773,22 @@ func newStartVMCommand() *cobra.Command {
 
 // startVMWithProvider starts a VM on the specified provider with interactive selector
 func startVMWithProvider(name, provider string) error {
-	normalizedProvider, err := normalizeVMProvider(provider)
-	if err != nil {
-		return err
-	}
-
-	name, err = chooseVMNameForProvider(name, normalizedProvider, "start")
-	if err != nil {
-		return err
-	}
-	if name == "" {
-		return nil
-	}
-
-	// Call appropriate start function based on provider
-	switch normalizedProvider {
-	case "truenas":
-		return startTrueNASVMFn(name)
-	case "proxmox":
-		return startProxmoxVMFn(name)
-	case "vsphere":
-		return powerOnVSphereVMFn(name)
-	}
-
-	return nil
+	return runVMLifecycleAction(name, provider, "start", func(lifecycle vmprov.VMLifecycle, vmName string) error {
+		return lifecycle.StartVM(vmName)
+	})
 }
 
 // stopVMWithProvider stops a VM on the specified provider with interactive selector
 func stopVMWithProvider(name, provider string) error {
-	normalizedProvider, err := normalizeVMProvider(provider)
-	if err != nil {
-		return err
-	}
-
-	name, err = chooseVMNameForProvider(name, normalizedProvider, "stop")
-	if err != nil {
-		return err
-	}
-	if name == "" {
-		return nil
-	}
-
-	switch normalizedProvider {
-	case "truenas":
-		return stopTrueNASVMFn(name, false)
-	case "proxmox":
-		return stopProxmoxVMFn(name, false)
-	case "vsphere":
-		return powerOffVSphereVMFn(name)
-	}
-
-	return nil
+	return runVMLifecycleAction(name, provider, "stop", func(lifecycle vmprov.VMLifecycle, vmName string) error {
+		return lifecycle.StopVM(vmName, false)
+	})
 }
 
 // infoVMWithProvider gets VM info from the specified provider with interactive selector
 func infoVMWithProvider(name, provider string) error {
-	normalizedProvider, err := normalizeVMProvider(provider)
-	if err != nil {
-		return err
-	}
-
-	name, err = chooseVMNameForProvider(name, normalizedProvider, "get info")
-	if err != nil {
-		return err
-	}
-	if name == "" {
-		return nil
-	}
-
-	switch normalizedProvider {
-	case "truenas":
-		return infoTrueNASVMFn(name)
-	case "proxmox":
-		return infoProxmoxVMFn(name)
-	case "vsphere":
-		return infoVSphereVMFn(name)
-	}
-
-	return nil
-}
-
-// infoVMOnVSphere gets detailed VM information from vSphere/ESXi
-func infoVMOnVSphere(vmName string) error {
-	logger := common.NewColorLogger()
-	logger.Info("Getting vSphere/ESXi VM info: %s", vmName)
-
-	return withVSphereClient(logger, func(client vsphereClient) error {
-		vm, err := client.FindVM(vmName)
-		if err != nil {
-			return fmt.Errorf("failed to find VM %s: %w", vmName, err)
-		}
-
-		vmInfo, err := client.GetVMInfo(vm)
-		if err != nil {
-			return fmt.Errorf("failed to get VM info for %s: %w", vmName, err)
-		}
-
-		logger.Info("VM Information for: %s", vmName)
-		logger.Info("  Power State: %s", vmInfo.Runtime.PowerState)
-		logger.Info("  Guest OS: %s", vmInfo.Config.GuestFullName)
-		logger.Info("  CPUs: %d", vmInfo.Config.Hardware.NumCPU)
-		logger.Info("  Memory: %d MB", vmInfo.Config.Hardware.MemoryMB)
-		logger.Info("  UUID: %s", vmInfo.Config.Uuid)
-
-		if vmInfo.Guest != nil && vmInfo.Guest.IpAddress != "" {
-			logger.Info("  IP Address: %s", vmInfo.Guest.IpAddress)
-		}
-
-		return nil
-	})
-}
-
-func startVM(name string) error {
-	logger := common.NewColorLogger()
-	return withTrueNASVMManager(logger, func(vmManager trueNASVMManager) error {
-		return vmManager.StartVM(name)
+	return runVMLifecycleAction(name, provider, "get info", func(lifecycle vmprov.VMLifecycle, vmName string) error {
+		return lifecycle.GetVMInfo(vmName)
 	})
 }
 
@@ -2858,13 +2817,6 @@ func newStopVMCommand() *cobra.Command {
 	_ = cmd.RegisterFlagCompletionFunc("name", completion.ValidVMNames)
 
 	return cmd
-}
-
-func stopVM(name string, force bool) error {
-	logger := common.NewColorLogger()
-	return withTrueNASVMManager(logger, func(vmManager trueNASVMManager) error {
-		return vmManager.StopVM(name, force)
-	})
 }
 
 func newDeleteVMCommand() *cobra.Command {
@@ -2931,23 +2883,8 @@ func deleteVMWithConfirmation(name, provider string, force bool) error {
 		}
 	}
 
-	switch normalizedProvider {
-	case "truenas":
-		return deleteTrueNASVMFn(name)
-	case "proxmox":
-		return deleteProxmoxVMFn(name)
-	case "vsphere":
-		return deleteVSphereVMFn(name)
-	}
-
-	return nil
-}
-
-func deleteVM(name string) error {
-	logger := common.NewColorLogger()
-	storagePool := getEnvOrDefault("STORAGE_POOL", "flashstor")
-	return withTrueNASVMManager(logger, func(vmManager trueNASVMManager) error {
-		return vmManager.DeleteVM(name, true, storagePool)
+	return withVMLifecycle(normalizedProvider, func(lifecycle vmprov.VMLifecycle) error {
+		return lifecycle.DeleteVM(name)
 	})
 }
 
@@ -2976,13 +2913,6 @@ func newInfoVMCommand() *cobra.Command {
 	_ = cmd.RegisterFlagCompletionFunc("name", completion.ValidVMNames)
 
 	return cmd
-}
-
-func infoVM(name string) error {
-	logger := common.NewColorLogger()
-	return withTrueNASVMManager(logger, func(vmManager trueNASVMManager) error {
-		return vmManager.GetVMInfo(name)
-	})
 }
 
 // newPrepareISOCommand creates the prepare-iso command
@@ -3465,61 +3395,6 @@ func deployGenericVMOnVSphere(baseName string, host string, memory, vcpus, diskS
 }
 
 // deleteVMOnVSphere deletes a VM from vSphere/ESXi
-func deleteVMOnVSphere(vmName string) error {
-	logger := common.NewColorLogger()
-	logger.Info("Starting vSphere/ESXi VM deletion for: %s", vmName)
-	return withVSphereClient(logger, func(client vsphereClient) error {
-		vm, err := client.FindVM(vmName)
-		if err != nil {
-			return fmt.Errorf("failed to find VM %s: %w", vmName, err)
-		}
-
-		logger.Info("Found VM: %s", vmName)
-		if err := client.DeleteVM(vm); err != nil {
-			return fmt.Errorf("failed to delete VM %s: %w", vmName, err)
-		}
-
-		logger.Success("VM %s deleted successfully!", vmName)
-		return nil
-	})
-}
-
-// startVMOnProxmox starts a VM on Proxmox VE
-func startVMOnProxmox(name string) error {
-	logger := common.NewColorLogger()
-	logger.Info("Starting Proxmox VM: %s", name)
-	return withProxmoxVMManager(logger, func(vmManager proxmoxVMManager) error {
-		return vmManager.StartVM(name)
-	})
-}
-
-// stopVMOnProxmox stops a VM on Proxmox VE
-func stopVMOnProxmox(name string, force bool) error {
-	logger := common.NewColorLogger()
-	logger.Info("Stopping Proxmox VM: %s", name)
-	return withProxmoxVMManager(logger, func(vmManager proxmoxVMManager) error {
-		return vmManager.StopVM(name, force)
-	})
-}
-
-// deleteVMOnProxmox deletes a VM on Proxmox VE
-func deleteVMOnProxmox(name string) error {
-	logger := common.NewColorLogger()
-	logger.Info("Deleting Proxmox VM: %s", name)
-	return withProxmoxVMManager(logger, func(vmManager proxmoxVMManager) error {
-		return vmManager.DeleteVM(name)
-	})
-}
-
-// infoVMOnProxmox gets detailed VM information from Proxmox VE
-func infoVMOnProxmox(name string) error {
-	logger := common.NewColorLogger()
-	logger.Info("Getting Proxmox VM info: %s", name)
-	return withProxmoxVMManager(logger, func(vmManager proxmoxVMManager) error {
-		return vmManager.GetVMInfo(name)
-	})
-}
-
 func newPowerOnVMCommand() *cobra.Command {
 	var (
 		name     string
@@ -3576,91 +3451,14 @@ func newPowerOffVMCommand() *cobra.Command {
 
 // powerOnVM powers on a VM on the specified provider with interactive selector
 func powerOnVM(name, provider string) error {
-	normalizedProvider, err := normalizeVMProvider(provider)
-	if err != nil {
-		return err
-	}
-
-	name, err = chooseVMNameForProvider(name, normalizedProvider, "power on")
-	if err != nil {
-		return err
-	}
-	if name == "" {
-		return nil
-	}
-
-	switch normalizedProvider {
-	case "truenas":
-		return startTrueNASVMFn(name)
-	case "proxmox":
-		return startProxmoxVMFn(name)
-	case "vsphere":
-		return powerOnVSphereVMFn(name)
-	}
-
-	return nil
-}
-
-// powerOffVM powers off a VM on the specified provider with interactive selector
-func powerOffVM(name, provider string) error {
-	normalizedProvider, err := normalizeVMProvider(provider)
-	if err != nil {
-		return err
-	}
-
-	name, err = chooseVMNameForProvider(name, normalizedProvider, "power off")
-	if err != nil {
-		return err
-	}
-	if name == "" {
-		return nil
-	}
-
-	switch normalizedProvider {
-	case "truenas":
-		return stopTrueNASVMFn(name, true)
-	case "proxmox":
-		return stopProxmoxVMFn(name, true)
-	case "vsphere":
-		return powerOffVSphereVMFn(name)
-	}
-
-	return nil
-}
-
-func powerOnVMOnVSphere(vmName string) error {
-	logger := common.NewColorLogger()
-	logger.Info("Powering on vSphere/ESXi VM: %s", vmName)
-	return withVSphereClient(logger, func(client vsphereClient) error {
-		vm, err := client.FindVM(vmName)
-		if err != nil {
-			return fmt.Errorf("failed to find VM %s: %w", vmName, err)
-		}
-
-		if err := client.PowerOnVM(vm); err != nil {
-			return fmt.Errorf("failed to power on VM %s: %w", vmName, err)
-		}
-
-		logger.Success("VM %s powered on successfully!", vmName)
-		return nil
+	return runVMLifecycleAction(name, provider, "power on", func(lifecycle vmprov.VMLifecycle, vmName string) error {
+		return lifecycle.StartVM(vmName)
 	})
 }
 
-// powerOffVMOnVSphere powers off a VM on vSphere/ESXi
-func powerOffVMOnVSphere(vmName string) error {
-	logger := common.NewColorLogger()
-	logger.Info("Powering off vSphere/ESXi VM: %s", vmName)
-	return withVSphereClient(logger, func(client vsphereClient) error {
-		vm, err := client.FindVM(vmName)
-		if err != nil {
-			return fmt.Errorf("failed to find VM %s: %w", vmName, err)
-		}
-
-		if err := client.PowerOffVM(vm); err != nil {
-			return fmt.Errorf("failed to power off VM %s: %w", vmName, err)
-		}
-
-		logger.Success("VM %s powered off successfully!", vmName)
-		return nil
+// powerOffVM force-stops a VM on the specified provider with interactive selector
+func powerOffVM(name, provider string) error {
+	return runVMLifecycleAction(name, provider, "power off", func(lifecycle vmprov.VMLifecycle, vmName string) error {
+		return lifecycle.StopVM(vmName, true)
 	})
 }

--- a/cmd/homeops-cli/cmd/talos/talos_test.go
+++ b/cmd/homeops-cli/cmd/talos/talos_test.go
@@ -17,11 +17,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
-	"github.com/vmware/govmomi/vim25/types"
 	"homeops-cli/internal/common"
 	"homeops-cli/internal/constants"
 	"homeops-cli/internal/iso"
 	"homeops-cli/internal/proxmox"
+	vmprov "homeops-cli/internal/provider"
 	"homeops-cli/internal/ssh"
 	internaltalos "homeops-cli/internal/talos"
 	"homeops-cli/internal/truenas"
@@ -870,25 +870,70 @@ func TestRootVMLifecycleAliasReturnsManageVMGuidance(t *testing.T) {
 	assert.Contains(t, err.Error(), "--provider truenas")
 }
 
+// fakeVMLifecycle records lifecycle calls for dispatch tests.
+type fakeVMLifecycle struct {
+	provider string
+	calls    *[]string
+	closed   *int
+}
+
+func (f *fakeVMLifecycle) ListVMs() error {
+	*f.calls = append(*f.calls, "list-"+f.provider)
+	return nil
+}
+
+func (f *fakeVMLifecycle) StartVM(name string) error {
+	*f.calls = append(*f.calls, "start-"+f.provider+":"+name)
+	return nil
+}
+
+func (f *fakeVMLifecycle) StopVM(name string, force bool) error {
+	*f.calls = append(*f.calls, fmt.Sprintf("stop-%s:%s:%t", f.provider, name, force))
+	return nil
+}
+
+func (f *fakeVMLifecycle) DeleteVM(name string) error {
+	*f.calls = append(*f.calls, "delete-"+f.provider+":"+name)
+	return nil
+}
+
+func (f *fakeVMLifecycle) GetVMInfo(name string) error {
+	*f.calls = append(*f.calls, "info-"+f.provider+":"+name)
+	return nil
+}
+
+func (f *fakeVMLifecycle) Close() error {
+	if f.closed != nil {
+		*f.closed++
+	}
+	return nil
+}
+
+// injectFakeVMLifecycle swaps the lifecycle factory for one returning fakes
+// that record into the returned slice, restoring it after the test.
+func injectFakeVMLifecycle(t *testing.T) (*[]string, *int) {
+	t.Helper()
+	oldFactory := newVMLifecycleFn
+	t.Cleanup(func() { newVMLifecycleFn = oldFactory })
+
+	calls := &[]string{}
+	closed := new(int)
+	newVMLifecycleFn = func(normalizedProvider string) (vmprov.VMLifecycle, error) {
+		return &fakeVMLifecycle{provider: normalizedProvider, calls: calls, closed: closed}, nil
+	}
+	return calls, closed
+}
+
 func TestVMLifecycleProviderCapabilityError(t *testing.T) {
-	oldStartTrueNAS := startTrueNASVMFn
-	t.Cleanup(func() {
-		startTrueNASVMFn = oldStartTrueNAS
-	})
+	calls, _ := injectFakeVMLifecycle(t)
 
 	stubUnavailable1PasswordCLI(t)
 	t.Setenv(constants.EnvTrueNASHost, "")
 	t.Setenv(constants.EnvTrueNASAPIKey, "")
 
-	called := false
-	startTrueNASVMFn = func(name string) error {
-		called = true
-		return nil
-	}
-
 	_, err := testutil.ExecuteCommand(newStartVMCommand(), "--provider", "truenas", "--name", "tn-vm")
 	require.Error(t, err)
-	assert.False(t, called, "provider operation should not run when config-level prerequisites are missing")
+	assert.Empty(t, *calls, "provider operation should not run when config-level prerequisites are missing")
 	assert.Contains(t, err.Error(), "TrueNAS VM lifecycle commands require")
 	assert.Contains(t, err.Error(), "homeops-cli talos manage-vm start --provider truenas --name <vm-name>")
 	assert.Contains(t, err.Error(), constants.EnvTrueNASHost)
@@ -896,115 +941,19 @@ func TestVMLifecycleProviderCapabilityError(t *testing.T) {
 }
 
 func TestPowerOffVMDispatchesForceStop(t *testing.T) {
-	oldChoose := chooseVMFunc
-	oldTrueNASGetter := getTrueNASVMNamesFn
-	oldProxmoxGetter := getProxmoxVMNamesFn
-	oldStopTrueNAS := stopTrueNASVMFn
-	oldStopProxmox := stopProxmoxVMFn
-	t.Cleanup(func() {
-		chooseVMFunc = oldChoose
-		getTrueNASVMNamesFn = oldTrueNASGetter
-		getProxmoxVMNamesFn = oldProxmoxGetter
-		stopTrueNASVMFn = oldStopTrueNAS
-		stopProxmoxVMFn = oldStopProxmox
-	})
-
-	var truenasForce, proxmoxForce bool
-	stopTrueNASVMFn = func(name string, force bool) error {
-		assert.Equal(t, "tn-vm", name)
-		truenasForce = force
-		return nil
-	}
-	stopProxmoxVMFn = func(name string, force bool) error {
-		assert.Equal(t, "px-vm", name)
-		proxmoxForce = force
-		return nil
-	}
+	calls, _ := injectFakeVMLifecycle(t)
 
 	require.NoError(t, powerOffVM("tn-vm", "truenas"))
-	assert.True(t, truenasForce)
-
 	require.NoError(t, powerOffVM("px-vm", "proxmox"))
-	assert.True(t, proxmoxForce)
+
+	assert.Equal(t, []string{
+		"stop-truenas:tn-vm:true",
+		"stop-proxmox:px-vm:true",
+	}, *calls)
 }
 
 func TestProviderLifecycleDispatch(t *testing.T) {
-	oldStartTrueNAS := startTrueNASVMFn
-	oldStartProxmox := startProxmoxVMFn
-	oldPowerOnVSphere := powerOnVSphereVMFn
-	oldStopTrueNAS := stopTrueNASVMFn
-	oldStopProxmox := stopProxmoxVMFn
-	oldPowerOffVSphere := powerOffVSphereVMFn
-	oldInfoTrueNAS := infoTrueNASVMFn
-	oldInfoProxmox := infoProxmoxVMFn
-	oldInfoVSphere := infoVSphereVMFn
-	oldDeleteTrueNAS := deleteTrueNASVMFn
-	oldDeleteProxmox := deleteProxmoxVMFn
-	oldDeleteVSphere := deleteVSphereVMFn
-	t.Cleanup(func() {
-		startTrueNASVMFn = oldStartTrueNAS
-		startProxmoxVMFn = oldStartProxmox
-		powerOnVSphereVMFn = oldPowerOnVSphere
-		stopTrueNASVMFn = oldStopTrueNAS
-		stopProxmoxVMFn = oldStopProxmox
-		powerOffVSphereVMFn = oldPowerOffVSphere
-		infoTrueNASVMFn = oldInfoTrueNAS
-		infoProxmoxVMFn = oldInfoProxmox
-		infoVSphereVMFn = oldInfoVSphere
-		deleteTrueNASVMFn = oldDeleteTrueNAS
-		deleteProxmoxVMFn = oldDeleteProxmox
-		deleteVSphereVMFn = oldDeleteVSphere
-	})
-
-	var calls []string
-	startTrueNASVMFn = func(name string) error {
-		calls = append(calls, "start-truenas:"+name)
-		return nil
-	}
-	startProxmoxVMFn = func(name string) error {
-		calls = append(calls, "start-proxmox:"+name)
-		return nil
-	}
-	powerOnVSphereVMFn = func(name string) error {
-		calls = append(calls, "start-vsphere:"+name)
-		return nil
-	}
-	stopTrueNASVMFn = func(name string, force bool) error {
-		calls = append(calls, fmt.Sprintf("stop-truenas:%s:%t", name, force))
-		return nil
-	}
-	stopProxmoxVMFn = func(name string, force bool) error {
-		calls = append(calls, fmt.Sprintf("stop-proxmox:%s:%t", name, force))
-		return nil
-	}
-	powerOffVSphereVMFn = func(name string) error {
-		calls = append(calls, "stop-vsphere:"+name)
-		return nil
-	}
-	infoTrueNASVMFn = func(name string) error {
-		calls = append(calls, "info-truenas:"+name)
-		return nil
-	}
-	infoProxmoxVMFn = func(name string) error {
-		calls = append(calls, "info-proxmox:"+name)
-		return nil
-	}
-	infoVSphereVMFn = func(name string) error {
-		calls = append(calls, "info-vsphere:"+name)
-		return nil
-	}
-	deleteTrueNASVMFn = func(name string) error {
-		calls = append(calls, "delete-truenas:"+name)
-		return nil
-	}
-	deleteProxmoxVMFn = func(name string) error {
-		calls = append(calls, "delete-proxmox:"+name)
-		return nil
-	}
-	deleteVSphereVMFn = func(name string) error {
-		calls = append(calls, "delete-vsphere:"+name)
-		return nil
-	}
+	calls, closed := injectFakeVMLifecycle(t)
 
 	require.NoError(t, startVMWithProvider("tn-vm", "truenas"))
 	require.NoError(t, startVMWithProvider("px-vm", "proxmox"))
@@ -1022,6 +971,7 @@ func TestProviderLifecycleDispatch(t *testing.T) {
 	require.NoError(t, powerOnVM("px-vm", "proxmox"))
 	require.NoError(t, powerOnVM("esx-vm", "vsphere"))
 	require.NoError(t, powerOffVM("esx-vm", "vsphere"))
+	require.NoError(t, listVMs("proxmox"))
 
 	assert.Equal(t, []string{
 		"start-truenas:tn-vm",
@@ -1029,7 +979,7 @@ func TestProviderLifecycleDispatch(t *testing.T) {
 		"start-vsphere:esx-vm",
 		"stop-truenas:tn-vm:false",
 		"stop-proxmox:px-vm:false",
-		"stop-vsphere:esx-vm",
+		"stop-vsphere:esx-vm:false",
 		"info-truenas:tn-vm",
 		"info-proxmox:px-vm",
 		"info-vsphere:esx-vm",
@@ -1039,8 +989,10 @@ func TestProviderLifecycleDispatch(t *testing.T) {
 		"start-truenas:tn-vm",
 		"start-proxmox:px-vm",
 		"start-vsphere:esx-vm",
-		"stop-vsphere:esx-vm",
-	}, calls)
+		"stop-vsphere:esx-vm:true",
+		"list-proxmox",
+	}, *calls)
+	assert.Equal(t, 17, *closed, "every lifecycle instance must be closed")
 }
 
 func TestDeployDryRunPaths(t *testing.T) {
@@ -1101,50 +1053,19 @@ func TestBuildProxmoxDeploymentPlanPresetBatchDetails(t *testing.T) {
 
 func TestVMLifecycleCommandWrappers(t *testing.T) {
 	oldEnsureProvider := ensureVMLifecycleProviderFn
-	oldStartProxmox := startProxmoxVMFn
-	oldStopProxmox := stopProxmoxVMFn
-	oldDeleteProxmox := deleteProxmoxVMFn
-	oldInfoProxmox := infoProxmoxVMFn
-	oldPowerOnVSphere := powerOnVSphereVMFn
-	oldPowerOffVSphere := powerOffVSphereVMFn
+	oldFactory := newVMLifecycleFn
 	t.Cleanup(func() {
 		ensureVMLifecycleProviderFn = oldEnsureProvider
-		startProxmoxVMFn = oldStartProxmox
-		stopProxmoxVMFn = oldStopProxmox
-		deleteProxmoxVMFn = oldDeleteProxmox
-		infoProxmoxVMFn = oldInfoProxmox
-		powerOnVSphereVMFn = oldPowerOnVSphere
-		powerOffVSphereVMFn = oldPowerOffVSphere
+		newVMLifecycleFn = oldFactory
 	})
 
-	var calls []string
+	calls := &[]string{}
 	ensureVMLifecycleProviderFn = func(provider, action string) error {
-		calls = append(calls, "check:"+provider+":"+action)
+		*calls = append(*calls, "check:"+provider+":"+action)
 		return nil
 	}
-	startProxmoxVMFn = func(name string) error {
-		calls = append(calls, "start:"+name)
-		return nil
-	}
-	stopProxmoxVMFn = func(name string, force bool) error {
-		calls = append(calls, fmt.Sprintf("stop:%s:%t", name, force))
-		return nil
-	}
-	deleteProxmoxVMFn = func(name string) error {
-		calls = append(calls, "delete:"+name)
-		return nil
-	}
-	infoProxmoxVMFn = func(name string) error {
-		calls = append(calls, "info:"+name)
-		return nil
-	}
-	powerOnVSphereVMFn = func(name string) error {
-		calls = append(calls, "poweron:"+name)
-		return nil
-	}
-	powerOffVSphereVMFn = func(name string) error {
-		calls = append(calls, "poweroff:"+name)
-		return nil
+	newVMLifecycleFn = func(normalizedProvider string) (vmprov.VMLifecycle, error) {
+		return &fakeVMLifecycle{provider: normalizedProvider, calls: calls}, nil
 	}
 
 	_, err := testutil.ExecuteCommand(newDeployVMCommand(), "--provider", "proxmox", "--name", "k8s-0", "--dry-run")
@@ -1169,18 +1090,18 @@ func TestVMLifecycleCommandWrappers(t *testing.T) {
 
 	assert.Equal(t, []string{
 		"check:proxmox:start",
-		"start:px-vm",
+		"start-proxmox:px-vm",
 		"check:proxmox:stop",
-		"stop:px-vm:false",
+		"stop-proxmox:px-vm:false",
 		"check:proxmox:delete",
-		"delete:px-vm",
+		"delete-proxmox:px-vm",
 		"check:proxmox:info",
-		"info:px-vm",
+		"info-proxmox:px-vm",
 		"check:vsphere:poweron",
-		"poweron:esx-vm",
+		"start-vsphere:esx-vm",
 		"check:vsphere:poweroff",
-		"poweroff:esx-vm",
-	}, calls)
+		"stop-vsphere:esx-vm:true",
+	}, *calls)
 }
 
 func TestDeployVMCommandProviderValidation(t *testing.T) {
@@ -1709,10 +1630,10 @@ func TestHypervisorWrapperFlows(t *testing.T) {
 		defer cleanup()
 
 		require.NoError(t, listVMs("truenas"))
-		require.NoError(t, startVM("tn-vm"))
-		require.NoError(t, stopVM("tn-vm", true))
-		require.NoError(t, deleteVM("tn-vm"))
-		require.NoError(t, infoVM("tn-vm"))
+		require.NoError(t, startVMWithProvider("tn-vm", "truenas"))
+		require.NoError(t, powerOffVM("tn-vm", "truenas"))
+		require.NoError(t, deleteVMWithConfirmation("tn-vm", "truenas", true))
+		require.NoError(t, infoVMWithProvider("tn-vm", "truenas"))
 		require.NoError(t, cleanupOrphanedZVols("tn-vm", "flashstor"))
 
 		assert.Equal(t, 6, manager.connectCalls)
@@ -1740,10 +1661,10 @@ func TestHypervisorWrapperFlows(t *testing.T) {
 		}
 
 		require.NoError(t, listVMs("proxmox"))
-		require.NoError(t, startVMOnProxmox("px-vm"))
-		require.NoError(t, stopVMOnProxmox("px-vm", true))
-		require.NoError(t, deleteVMOnProxmox("px-vm"))
-		require.NoError(t, infoVMOnProxmox("px-vm"))
+		require.NoError(t, startVMWithProvider("px-vm", "proxmox"))
+		require.NoError(t, powerOffVM("px-vm", "proxmox"))
+		require.NoError(t, deleteVMWithConfirmation("px-vm", "proxmox", true))
+		require.NoError(t, infoVMWithProvider("px-vm", "proxmox"))
 
 		prepareISOForTargetFn = func(target isoPreparationTarget) error {
 			assert.Equal(t, "Proxmox", target.providerName)
@@ -1762,23 +1683,27 @@ func TestHypervisorWrapperFlows(t *testing.T) {
 	})
 
 	t.Run("vsphere wrappers", func(t *testing.T) {
-		client := &fakeVSphereClient{
-			infoResponse: &mo.VirtualMachine{
-				Runtime: types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOn},
-				Config: &types.VirtualMachineConfigInfo{
-					GuestFullName: "Talos Linux",
-					Uuid:          "vm-uuid",
-					Hardware:      types.VirtualHardware{NumCPU: 4, MemoryMB: 8192},
-				},
-				Guest: &types.GuestInfo{IpAddress: "10.0.0.99"},
-			},
-		}
+		client := &fakeVSphereClient{}
 		getVSphereCredsFn = func() (string, string, string, error) {
 			return "esxi.local", "root", "secret", nil
 		}
 		newVSphereClientFn = func(host, username, password string, insecure bool) vsphereClient {
 			return client
 		}
+
+		oldVSphereVMManagerFactory := newVSphereVMManagerFn
+		t.Cleanup(func() { newVSphereVMManagerFn = oldVSphereVMManagerFactory })
+		calls := &[]string{}
+		var constructed int
+		newVSphereVMManagerFn = func(host, username, password string, insecure bool) (vmprov.VMLifecycle, error) {
+			assert.Equal(t, "esxi.local", host)
+			assert.Equal(t, "root", username)
+			assert.Equal(t, "secret", password)
+			assert.False(t, insecure) // verify-by-default; VSPHERE_INSECURE unset in tests
+			constructed++
+			return &fakeVMLifecycle{provider: "vsphere", calls: calls}, nil
+		}
+
 		httpGetFn = func(url string) (*http.Response, error) {
 			return &http.Response{
 				StatusCode:    http.StatusOK,
@@ -1788,19 +1713,24 @@ func TestHypervisorWrapperFlows(t *testing.T) {
 		}
 
 		require.NoError(t, listVMs("vsphere"))
-		require.NoError(t, infoVMOnVSphere("esx-vm"))
-		require.NoError(t, powerOnVMOnVSphere("esx-vm"))
-		require.NoError(t, powerOffVMOnVSphere("esx-vm"))
-		require.NoError(t, deleteVMOnVSphere("esx-vm"))
+		require.NoError(t, infoVMWithProvider("esx-vm", "vsphere"))
+		require.NoError(t, powerOnVM("esx-vm", "vsphere"))
+		require.NoError(t, powerOffVM("esx-vm", "vsphere"))
+		require.NoError(t, deleteVMWithConfirmation("esx-vm", "vsphere", true))
 		require.NoError(t, uploadISOToVSphere("https://example.com/vsphere.iso"))
 
-		assert.Equal(t, 6, client.connectCalls)
-		assert.Equal(t, 6, client.closeCalls)
-		assert.Equal(t, 1, client.listCount)
-		assert.Equal(t, []string{"esx-vm", "esx-vm", "esx-vm", "esx-vm"}, client.foundNames)
-		assert.Equal(t, 1, client.poweredOn)
-		assert.Equal(t, 1, client.poweredOff)
-		assert.Equal(t, 1, client.deleted)
+		assert.Equal(t, 5, constructed, "each lifecycle op constructs and closes a manager")
+		assert.Equal(t, []string{
+			"list-vsphere",
+			"info-vsphere:esx-vm",
+			"start-vsphere:esx-vm",
+			"stop-vsphere:esx-vm:true",
+			"delete-vsphere:esx-vm",
+		}, *calls)
+
+		// ISO upload still flows through the raw vSphere client.
+		assert.Equal(t, 1, client.connectCalls)
+		assert.Equal(t, 1, client.closeCalls)
 		require.Len(t, client.uploads, 1)
 		assert.Contains(t, client.uploads[0], vsphere.DefaultISODatastore)
 		assert.Contains(t, client.uploads[0], vsphere.DefaultISOFilename)
@@ -1871,12 +1801,12 @@ func TestKubeconfigFlows(t *testing.T) {
 
 func TestDeleteAndCleanupConfirmationFlows(t *testing.T) {
 	oldConfirm := confirmActionFn
-	oldDeleteTrueNAS := deleteTrueNASVMFn
+	oldFactory := newVMLifecycleFn
 	oldTrueNASFactory := newTrueNASVMManagerFn
 	oldTrueNASCreds := getTrueNASCredentialsFn
 	t.Cleanup(func() {
 		confirmActionFn = oldConfirm
-		deleteTrueNASVMFn = oldDeleteTrueNAS
+		newVMLifecycleFn = oldFactory
 		newTrueNASVMManagerFn = oldTrueNASFactory
 		getTrueNASCredentialsFn = oldTrueNASCreds
 	})
@@ -1887,15 +1817,14 @@ func TestDeleteAndCleanupConfirmationFlows(t *testing.T) {
 			message = msg
 			return true, nil
 		}
-		var deleted string
-		deleteTrueNASVMFn = func(name string) error {
-			deleted = name
-			return nil
+		calls := &[]string{}
+		newVMLifecycleFn = func(normalizedProvider string) (vmprov.VMLifecycle, error) {
+			return &fakeVMLifecycle{provider: normalizedProvider, calls: calls}, nil
 		}
 
 		require.NoError(t, deleteVMWithConfirmation("tn-vm", "truenas", false))
 		assert.Contains(t, message, "all its ZVols on TrueNAS")
-		assert.Equal(t, "tn-vm", deleted)
+		assert.Equal(t, []string{"delete-truenas:tn-vm"}, *calls)
 	})
 
 	t.Run("cleanup zvol command force wrapper", func(t *testing.T) {

--- a/cmd/homeops-cli/internal/common/kubeconfig.go
+++ b/cmd/homeops-cli/internal/common/kubeconfig.go
@@ -75,9 +75,9 @@ func SaveKubeconfigTo1Password(kubeconfigContent []byte, logger *ColorLogger) er
 func PullKubeconfigFrom1Password(destPath string, logger *ColorLogger) error {
 	logger.Debug("Pulling kubeconfig from 1Password...")
 
-	// Ensure destination directory exists
+	// Ensure destination directory exists (owner-only: holds credentials)
 	destDir := filepath.Dir(destPath)
-	if err := os.MkdirAll(destDir, 0755); err != nil {
+	if err := os.MkdirAll(destDir, 0700); err != nil {
 		return fmt.Errorf("failed to create destination directory: %w", err)
 	}
 

--- a/cmd/homeops-cli/internal/errors/errors_test.go
+++ b/cmd/homeops-cli/internal/errors/errors_test.go
@@ -1,7 +1,6 @@
 package errors
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -19,89 +18,5 @@ func TestHomeOpsError(t *testing.T) {
 
 	if err.Message != "Test message" {
 		t.Errorf("Expected message 'Test message', got %s", err.Message)
-	}
-}
-
-// TestErrorContext tests error context functionality
-func TestErrorContext(t *testing.T) {
-	err := NewValidationError("TEST_CODE", "Test message", nil).
-		WithContext("test_operation", "test_component").
-		WithRequestID("req-123").
-		WithStackTrace()
-
-	if err.Context == nil {
-		t.Fatal("Expected error context to be set")
-	}
-
-	if err.Context.Operation != "test_operation" {
-		t.Errorf("Expected operation 'test_operation', got %s", err.Context.Operation)
-	}
-
-	if err.Context.Component != "test_component" {
-		t.Errorf("Expected component 'test_component', got %s", err.Context.Component)
-	}
-
-	if err.Context.RequestID != "req-123" {
-		t.Errorf("Expected request ID 'req-123', got %s", err.Context.RequestID)
-	}
-
-	if len(err.Context.StackTrace) == 0 {
-		t.Error("Expected stack trace to be captured")
-	}
-}
-
-// TestUserFriendlyMessages tests user-friendly error messages
-func TestUserFriendlyMessages(t *testing.T) {
-	tests := []struct {
-		errorType       ErrorType
-		code            string
-		expectedActions int
-	}{
-		{ErrTypeValidation, "REQUIRED_FIELD", 1},
-		{ErrTypeKubernetes, "CONNECTION_FAILED", 2},
-		{ErrTypeSecurity, "ENCRYPTION_FAILED", 2},
-		{ErrTypeFileSystem, "FILE_NOT_FOUND", 2},
-	}
-
-	for _, test := range tests {
-		t.Run(fmt.Sprintf("%s_%s", test.errorType, test.code), func(t *testing.T) {
-			var err *HomeOpsError
-			switch test.errorType {
-			case ErrTypeValidation:
-				err = NewValidationError(test.code, "Test message", nil)
-			case ErrTypeKubernetes:
-				err = NewKubernetesError(test.code, "Test message", nil)
-			case ErrTypeSecurity:
-				err = NewSecurityError(test.code, "Test message", nil)
-			case ErrTypeFileSystem:
-				err = NewFileSystemError(test.code, "Test message", nil)
-			}
-
-			msg := err.GetUserFriendlyMessage()
-			if msg == nil {
-				t.Fatal("Expected user-friendly message to be generated")
-				return // This return is needed to satisfy staticcheck
-			}
-
-			if len(msg.SuggestedActions) < test.expectedActions {
-				t.Errorf("Expected at least %d suggested actions, got %d",
-					test.expectedActions, len(msg.SuggestedActions))
-			}
-
-			if msg.UserMessage == "" {
-				t.Error("Expected user message to be set")
-			}
-		})
-	}
-}
-
-// BenchmarkErrorCreation benchmarks error creation performance
-func BenchmarkErrorCreation(b *testing.B) {
-	b.ResetTimer()
-	for b.Loop() {
-		err := NewValidationError("TEST_CODE", "Test message", nil).
-			WithContext("test_operation", "test_component").
-			WithRequestID("req-123")
-		_ = err
 	}
 }

--- a/cmd/homeops-cli/internal/errors/helpers_test.go
+++ b/cmd/homeops-cli/internal/errors/helpers_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConstructorsAndWrapHelpers(t *testing.T) {
+func TestConstructors(t *testing.T) {
 	cause := stderrors.New("boom")
 
 	tests := []struct {
@@ -17,11 +17,7 @@ func TestConstructorsAndWrapHelpers(t *testing.T) {
 		typ  ErrorType
 	}{
 		{"template", NewTemplateError("TPL", "template failed", cause), ErrTypeTemplate},
-		{"kubernetes", NewKubernetesError("K8S", "k8s failed", cause), ErrTypeKubernetes},
-		{"talos", NewTalosError("TALOS", "talos failed", cause), ErrTypeTalos},
 		{"validation", NewValidationError("VAL", "validation failed", cause), ErrTypeValidation},
-		{"network", NewNetworkError("NET", "network failed", cause), ErrTypeNetwork},
-		{"config", NewConfigError("CFG", "config failed", cause), ErrTypeConfig},
 		{"security", NewSecurityError("SEC", "security failed", cause), ErrTypeSecurity},
 		{"filesystem", NewFileSystemError("FS", "filesystem failed", cause), ErrTypeFileSystem},
 		{"notfound", NewNotFoundError("NF", "missing", cause), ErrTypeNotFound},
@@ -33,85 +29,24 @@ func TestConstructorsAndWrapHelpers(t *testing.T) {
 			assert.Equal(t, tt.typ, tt.got.Type)
 			assert.ErrorIs(t, tt.got.Unwrap(), cause)
 			assert.True(t, IsType(tt.got, tt.typ))
-			typ, ok := GetType(tt.got)
-			require.True(t, ok)
-			assert.Equal(t, tt.typ, typ)
 		})
 	}
 
-	assert.Nil(t, Wrap(nil, ErrTypeTemplate, "CODE", "message"))
-	assert.Equal(t, ErrTypeTemplate, WrapTemplate(cause, "wrapped").Type)
-	assert.Equal(t, ErrTypeKubernetes, WrapKubernetes(cause, "wrapped").Type)
-	assert.Equal(t, ErrTypeTalos, WrapTalos(cause, "wrapped").Type)
-	assert.Equal(t, ErrTypeValidation, WrapValidation(cause, "wrapped").Type)
-	assert.Equal(t, ErrTypeNetwork, WrapNetwork(cause, "wrapped").Type)
-	assert.Equal(t, ErrTypeConfig, WrapConfig(cause, "wrapped").Type)
-	assert.Equal(t, ErrTypeFileSystem, WrapFileSystem(cause, "wrapped").Type)
 	assert.False(t, IsType(stderrors.New("plain"), ErrTypeTemplate))
-	_, ok := GetType(stderrors.New("plain"))
-	assert.False(t, ok)
 }
 
-func TestHomeOpsErrorFormattingAndContextHelpers(t *testing.T) {
+func TestHomeOpsErrorFormatting(t *testing.T) {
 	cause := stderrors.New("disk full")
-	err := (&HomeOpsError{
+	err := &HomeOpsError{
 		Type:    ErrTypeFileSystem,
 		Code:    "FS001",
 		Message: "write failed",
 		Cause:   cause,
-	}).WithDetail("path", "/tmp/config.yaml").
-		WithContext("save", "bootstrap").
-		WithRequestID("req-123").
-		WithStackTrace()
+	}
 
 	assert.Contains(t, err.Error(), "FS001: write failed")
 	assert.Contains(t, err.Error(), "disk full")
-	assert.Equal(t, "/tmp/config.yaml", err.Details["path"])
-	require.NotNil(t, err.Context)
-	assert.Equal(t, "save", err.Context.Operation)
-	assert.Equal(t, "bootstrap", err.Context.Component)
-	assert.Equal(t, "req-123", err.Context.RequestID)
-	assert.NotZero(t, err.Context.Timestamp)
-	assert.NotEmpty(t, err.Context.StackTrace)
 
 	noCause := &HomeOpsError{Code: "GENERIC", Message: "plain error"}
 	assert.Equal(t, "GENERIC: plain error", noCause.Error())
-}
-
-func TestUserFriendlyMessagesForAllTypes(t *testing.T) {
-	tests := []struct {
-		name            string
-		errType         ErrorType
-		expectDocsLinks bool
-	}{
-		{"template", ErrTypeTemplate, true},
-		{"kubernetes", ErrTypeKubernetes, true},
-		{"talos", ErrTypeTalos, true},
-		{"validation", ErrTypeValidation, false},
-		{"network", ErrTypeNetwork, false},
-		{"config", ErrTypeConfig, false},
-		{"security", ErrTypeSecurity, false},
-		{"filesystem", ErrTypeFileSystem, false},
-		{"notfound", ErrTypeNotFound, false},
-		{"default", ErrorType("unknown"), false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := &HomeOpsError{
-				Type:    tt.errType,
-				Code:    "CODE",
-				Message: "message",
-				Cause:   stderrors.New("boom"),
-			}
-			msg := err.GetUserFriendlyMessage()
-			require.NotNil(t, msg)
-			assert.NotEmpty(t, msg.UserMessage)
-			assert.NotEmpty(t, msg.TechnicalDetails)
-			assert.NotEmpty(t, msg.SuggestedActions)
-			if tt.expectDocsLinks {
-				assert.NotEmpty(t, msg.DocumentationLinks)
-			}
-		})
-	}
 }

--- a/cmd/homeops-cli/internal/errors/types.go
+++ b/cmd/homeops-cli/internal/errors/types.go
@@ -1,9 +1,11 @@
+// Package errors provides typed, code-tagged errors for operations where the
+// category matters to callers (security checks, validation, template
+// rendering, filesystem access). Plain fmt.Errorf wrapping remains the norm
+// elsewhere; reach for these constructors when a caller branches on IsType.
 package errors
 
 import (
 	"fmt"
-	"runtime"
-	"time"
 )
 
 // ErrorType represents the category of error
@@ -11,42 +13,18 @@ type ErrorType string
 
 const (
 	ErrTypeTemplate   ErrorType = "template"
-	ErrTypeKubernetes ErrorType = "kubernetes"
-	ErrTypeTalos      ErrorType = "talos"
 	ErrTypeValidation ErrorType = "validation"
-	ErrTypeNetwork    ErrorType = "network"
-	ErrTypeConfig     ErrorType = "config"
 	ErrTypeSecurity   ErrorType = "security"
 	ErrTypeFileSystem ErrorType = "filesystem"
 	ErrTypeNotFound   ErrorType = "notfound"
 )
 
-// ErrorContext provides additional context for error tracking and debugging
-type ErrorContext struct {
-	Operation   string                 `json:"operation"`
-	Component   string                 `json:"component"`
-	RequestID   string                 `json:"request_id,omitempty"`
-	UserContext map[string]interface{} `json:"user_context,omitempty"`
-	Timestamp   time.Time              `json:"timestamp"`
-	StackTrace  []string               `json:"stack_trace,omitempty"`
-}
-
-// ErrorMessage provides user-friendly error information
-type ErrorMessage struct {
-	UserMessage        string   `json:"user_message"`
-	TechnicalDetails   string   `json:"technical_details"`
-	SuggestedActions   []string `json:"suggested_actions,omitempty"`
-	DocumentationLinks []string `json:"documentation_links,omitempty"`
-}
-
-// HomeOpsError represents a structured error with context
+// HomeOpsError represents a structured error with a category and stable code
 type HomeOpsError struct {
-	Type    ErrorType              `json:"type"`
-	Code    string                 `json:"code"`
-	Message string                 `json:"message"`
-	Details map[string]interface{} `json:"details,omitempty"`
-	Cause   error                  `json:"-"`
-	Context *ErrorContext          `json:"context,omitempty"`
+	Type    ErrorType `json:"type"`
+	Code    string    `json:"code"`
+	Message string    `json:"message"`
+	Cause   error     `json:"-"`
 }
 
 // Error implements the error interface
@@ -62,247 +40,29 @@ func (e *HomeOpsError) Unwrap() error {
 	return e.Cause
 }
 
-// WithDetail adds a detail to the error
-func (e *HomeOpsError) WithDetail(key string, value interface{}) *HomeOpsError {
-	if e.Details == nil {
-		e.Details = make(map[string]interface{})
-	}
-	e.Details[key] = value
-	return e
-}
-
-// WithContext adds context information to the error
-func (e *HomeOpsError) WithContext(operation, component string) *HomeOpsError {
-	if e.Context == nil {
-		e.Context = &ErrorContext{
-			Timestamp: time.Now(),
-		}
-	}
-	e.Context.Operation = operation
-	e.Context.Component = component
-	return e
-}
-
-// WithRequestID adds a request ID to the error context
-func (e *HomeOpsError) WithRequestID(requestID string) *HomeOpsError {
-	if e.Context == nil {
-		e.Context = &ErrorContext{
-			Timestamp: time.Now(),
-		}
-	}
-	e.Context.RequestID = requestID
-	return e
-}
-
-// WithStackTrace captures the current stack trace
-func (e *HomeOpsError) WithStackTrace() *HomeOpsError {
-	if e.Context == nil {
-		e.Context = &ErrorContext{
-			Timestamp: time.Now(),
-		}
-	}
-
-	// Capture stack trace
-	var stackTrace []string
-	for i := 1; i < 10; i++ { // Limit to 10 frames
-		_, file, line, ok := runtime.Caller(i)
-		if !ok {
-			break
-		}
-		stackTrace = append(stackTrace, fmt.Sprintf("%s:%d", file, line))
-	}
-	e.Context.StackTrace = stackTrace
-	return e
-}
-
-// GetUserFriendlyMessage returns a user-friendly error message with suggestions
-func (e *HomeOpsError) GetUserFriendlyMessage() *ErrorMessage {
-	msg := &ErrorMessage{
-		TechnicalDetails: e.Error(),
-	}
-
-	// Generate user-friendly messages based on error type and code
-	switch e.Type {
-	case ErrTypeTemplate:
-		msg.UserMessage = "Template processing failed"
-		msg.SuggestedActions = []string{
-			"Check template syntax and variables",
-			"Verify 1Password secrets are accessible",
-			"Ensure template file exists and is readable",
-		}
-	case ErrTypeKubernetes:
-		msg.UserMessage = "Kubernetes operation failed"
-		msg.SuggestedActions = []string{
-			"Check cluster connectivity",
-			"Verify KUBECONFIG is set correctly",
-			"Ensure required permissions are granted",
-		}
-	case ErrTypeTalos:
-		msg.UserMessage = "Talos operation failed"
-		msg.SuggestedActions = []string{
-			"Check Talos node connectivity",
-			"Verify TALOSCONFIG is set correctly",
-			"Ensure talosctl is installed and accessible",
-		}
-	case ErrTypeValidation:
-		msg.UserMessage = "Configuration validation failed"
-		msg.SuggestedActions = []string{
-			"Review configuration parameters",
-			"Check required fields are provided",
-			"Validate configuration format",
-		}
-	case ErrTypeNetwork:
-		msg.UserMessage = "Network operation failed"
-		msg.SuggestedActions = []string{
-			"Check network connectivity",
-			"Verify firewall settings",
-			"Ensure target services are running",
-		}
-	case ErrTypeConfig:
-		msg.UserMessage = "Configuration error"
-		msg.SuggestedActions = []string{
-			"Check configuration file syntax",
-			"Verify environment variables are set",
-			"Ensure configuration file exists",
-		}
-	case ErrTypeSecurity:
-		msg.UserMessage = "Security operation failed"
-		msg.SuggestedActions = []string{
-			"Check authentication credentials",
-			"Verify access permissions",
-			"Ensure security tokens are valid",
-		}
-	case ErrTypeFileSystem:
-		msg.UserMessage = "File system operation failed"
-		msg.SuggestedActions = []string{
-			"Check file/directory permissions",
-			"Verify file path exists",
-			"Ensure sufficient disk space",
-		}
-	case ErrTypeNotFound:
-		msg.UserMessage = "Resource not found"
-		msg.SuggestedActions = []string{
-			"Verify resource name and path",
-			"Check if resource exists",
-			"Ensure proper access permissions",
-		}
-	default:
-		msg.UserMessage = "An error occurred"
-		msg.SuggestedActions = []string{
-			"Check the error details for more information",
-			"Retry the operation",
-			"Contact support if the issue persists",
-		}
-	}
-
-	// Add documentation links based on error type
-	switch e.Type {
-	case ErrTypeTemplate:
-		msg.DocumentationLinks = []string{
-			"https://github.com/flosch/pongo2",
-			"https://1password.com/developers/connect/",
-		}
-	case ErrTypeKubernetes:
-		msg.DocumentationLinks = []string{
-			"https://kubernetes.io/docs/reference/kubectl/",
-		}
-	case ErrTypeTalos:
-		msg.DocumentationLinks = []string{
-			"https://www.talos.dev/docs/",
-		}
-	}
-
-	return msg
-}
-
 // NewTemplateError creates a new template-related error
 func NewTemplateError(code, message string, cause error) *HomeOpsError {
-	return &HomeOpsError{
-		Type:    ErrTypeTemplate,
-		Code:    code,
-		Message: message,
-		Cause:   cause,
-	}
-}
-
-// NewKubernetesError creates a new Kubernetes-related error
-func NewKubernetesError(code, message string, cause error) *HomeOpsError {
-	return &HomeOpsError{
-		Type:    ErrTypeKubernetes,
-		Code:    code,
-		Message: message,
-		Cause:   cause,
-	}
-}
-
-// NewTalosError creates a new Talos-related error
-func NewTalosError(code, message string, cause error) *HomeOpsError {
-	return &HomeOpsError{
-		Type:    ErrTypeTalos,
-		Code:    code,
-		Message: message,
-		Cause:   cause,
-	}
+	return &HomeOpsError{Type: ErrTypeTemplate, Code: code, Message: message, Cause: cause}
 }
 
 // NewValidationError creates a new validation error
 func NewValidationError(code, message string, cause error) *HomeOpsError {
-	return &HomeOpsError{
-		Type:    ErrTypeValidation,
-		Code:    code,
-		Message: message,
-		Cause:   cause,
-	}
-}
-
-// NewNetworkError creates a new network-related error
-func NewNetworkError(code, message string, cause error) *HomeOpsError {
-	return &HomeOpsError{
-		Type:    ErrTypeNetwork,
-		Code:    code,
-		Message: message,
-		Cause:   cause,
-	}
-}
-
-// NewConfigError creates a new configuration error
-func NewConfigError(code, message string, cause error) *HomeOpsError {
-	return &HomeOpsError{
-		Type:    ErrTypeConfig,
-		Code:    code,
-		Message: message,
-		Cause:   cause,
-	}
+	return &HomeOpsError{Type: ErrTypeValidation, Code: code, Message: message, Cause: cause}
 }
 
 // NewSecurityError creates a new security-related error
 func NewSecurityError(code, message string, cause error) *HomeOpsError {
-	return &HomeOpsError{
-		Type:    ErrTypeSecurity,
-		Code:    code,
-		Message: message,
-		Cause:   cause,
-	}
+	return &HomeOpsError{Type: ErrTypeSecurity, Code: code, Message: message, Cause: cause}
 }
 
 // NewFileSystemError creates a new filesystem error
 func NewFileSystemError(code, message string, cause error) *HomeOpsError {
-	return &HomeOpsError{
-		Type:    ErrTypeFileSystem,
-		Code:    code,
-		Message: message,
-		Cause:   cause,
-	}
+	return &HomeOpsError{Type: ErrTypeFileSystem, Code: code, Message: message, Cause: cause}
 }
 
 // NewNotFoundError creates a new not found error
 func NewNotFoundError(code, message string, cause error) *HomeOpsError {
-	return &HomeOpsError{
-		Type:    ErrTypeNotFound,
-		Code:    code,
-		Message: message,
-		Cause:   cause,
-	}
+	return &HomeOpsError{Type: ErrTypeNotFound, Code: code, Message: message, Cause: cause}
 }
 
 // IsType checks if an error is of a specific type
@@ -311,61 +71,4 @@ func IsType(err error, errorType ErrorType) bool {
 		return homeOpsErr.Type == errorType
 	}
 	return false
-}
-
-// GetType returns the error type if it's a HomeOpsError
-func GetType(err error) (ErrorType, bool) {
-	if homeOpsErr, ok := err.(*HomeOpsError); ok {
-		return homeOpsErr.Type, true
-	}
-	return "", false
-}
-
-// Wrap wraps a standard error into a HomeOpsError with context.
-// This is a convenience function for gradually migrating from fmt.Errorf.
-func Wrap(err error, errType ErrorType, code, message string) *HomeOpsError {
-	if err == nil {
-		return nil
-	}
-	return &HomeOpsError{
-		Type:    errType,
-		Code:    code,
-		Message: message,
-		Cause:   err,
-	}
-}
-
-// WrapTemplate wraps an error as a template error
-func WrapTemplate(err error, message string) *HomeOpsError {
-	return Wrap(err, ErrTypeTemplate, "TEMPLATE_ERROR", message)
-}
-
-// WrapKubernetes wraps an error as a Kubernetes error
-func WrapKubernetes(err error, message string) *HomeOpsError {
-	return Wrap(err, ErrTypeKubernetes, "K8S_ERROR", message)
-}
-
-// WrapTalos wraps an error as a Talos error
-func WrapTalos(err error, message string) *HomeOpsError {
-	return Wrap(err, ErrTypeTalos, "TALOS_ERROR", message)
-}
-
-// WrapValidation wraps an error as a validation error
-func WrapValidation(err error, message string) *HomeOpsError {
-	return Wrap(err, ErrTypeValidation, "VALIDATION_ERROR", message)
-}
-
-// WrapNetwork wraps an error as a network error
-func WrapNetwork(err error, message string) *HomeOpsError {
-	return Wrap(err, ErrTypeNetwork, "NETWORK_ERROR", message)
-}
-
-// WrapConfig wraps an error as a configuration error
-func WrapConfig(err error, message string) *HomeOpsError {
-	return Wrap(err, ErrTypeConfig, "CONFIG_ERROR", message)
-}
-
-// WrapFileSystem wraps an error as a filesystem error
-func WrapFileSystem(err error, message string) *HomeOpsError {
-	return Wrap(err, ErrTypeFileSystem, "FS_ERROR", message)
 }

--- a/cmd/homeops-cli/internal/metrics/collector.go
+++ b/cmd/homeops-cli/internal/metrics/collector.go
@@ -1,8 +1,11 @@
 package metrics
 
 import (
+	"sort"
 	"sync"
 	"time"
+
+	"homeops-cli/internal/common"
 )
 
 // PerformanceCollector tracks operation metrics
@@ -169,4 +172,36 @@ func (pc *PerformanceCollector) GetTotalOperations() int {
 	pc.mu.RLock()
 	defer pc.mu.RUnlock()
 	return len(pc.operations)
+}
+
+// LogReport writes a per-operation timing summary at debug level, sorted by
+// total time spent. Defer it where a collector is created so
+// `--log-level debug` shows where command time went.
+func (pc *PerformanceCollector) LogReport(logger *common.ColorLogger) {
+	report := pc.GetReport()
+	if len(report) == 0 {
+		return
+	}
+
+	type entry struct {
+		name  string
+		total time.Duration
+		op    OperationReport
+	}
+	entries := make([]entry, 0, len(report))
+	for name, op := range report {
+		entries = append(entries, entry{
+			name:  name,
+			total: op.AverageDuration * time.Duration(op.TotalCalls),
+			op:    op,
+		})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].total > entries[j].total })
+
+	logger.Debug("Performance report (%d operations):", len(entries))
+	for _, e := range entries {
+		logger.Debug("  %-30s calls=%-3d total=%-12s avg=%-12s errors=%.0f%%",
+			e.name, e.op.TotalCalls, e.total.Round(time.Millisecond),
+			e.op.AverageDuration.Round(time.Millisecond), e.op.ErrorRate*100)
+	}
 }

--- a/cmd/homeops-cli/internal/provider/provider.go
+++ b/cmd/homeops-cli/internal/provider/provider.go
@@ -1,0 +1,22 @@
+// Package provider defines the shared contracts that every hypervisor
+// provider (Proxmox, TrueNAS, vSphere/ESXi) implements, so command-layer
+// code can dispatch VM operations without per-provider switch statements.
+package provider
+
+// VMLifecycle is the name-addressed VM lifecycle contract. Construction and
+// provider-specific options (credentials, storage cleanup behaviour) live
+// with each implementation; everything past construction is uniform.
+//
+// Semantics each implementation must honour:
+//   - StopVM's force flag requests an ungraceful power-off where the
+//     platform distinguishes (providers without the distinction may ignore it).
+//   - DeleteVM removes the VM and any provider-default associated storage.
+//   - ListVMs and GetVMInfo print human-readable output to stdout/logger.
+type VMLifecycle interface {
+	ListVMs() error
+	StartVM(name string) error
+	StopVM(name string, force bool) error
+	DeleteVM(name string) error
+	GetVMInfo(name string) error
+	Close() error
+}

--- a/cmd/homeops-cli/internal/proxmox/vm_manager.go
+++ b/cmd/homeops-cli/internal/proxmox/vm_manager.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"homeops-cli/internal/common"
+	"homeops-cli/internal/provider"
 
 	"github.com/luthermonson/go-proxmox"
 )
@@ -19,6 +20,9 @@ var (
 	getCredentialsFn  = GetCredentials
 	newVMManagerFn    = NewVMManager
 )
+
+// VMManager satisfies the shared lifecycle contract used by command dispatch.
+var _ provider.VMLifecycle = (*VMManager)(nil)
 
 type taskHandle interface {
 	Wait(context.Context, time.Duration, time.Duration) error

--- a/cmd/homeops-cli/internal/ssh/ssh_client.go
+++ b/cmd/homeops-cli/internal/ssh/ssh_client.go
@@ -121,8 +121,9 @@ func (c *SSHClient) runSSHCommand(remoteArgs ...string) (common.CommandResult, e
 
 func (c *SSHClient) sshArgs() []string {
 	return []string{
-		"-o", "StrictHostKeyChecking=no",
-		"-o", "UserKnownHostsFile=/dev/null",
+		// Trust-on-first-use: record the host key on first connect, then
+		// refuse to connect if it ever changes (MITM protection).
+		"-o", "StrictHostKeyChecking=accept-new",
 		"-o", "IdentitiesOnly=yes",
 		"-o", "NumberOfPasswordPrompts=0",
 		"-p", c.port,

--- a/cmd/homeops-cli/internal/ssh/ssh_client_test.go
+++ b/cmd/homeops-cli/internal/ssh/ssh_client_test.go
@@ -59,8 +59,7 @@ func TestSSHClientConnectRedactsCommandOutputOnFailure(t *testing.T) {
 		assert.Equal(t, defaultSSHCommandTimeout, opts.Timeout)
 		assert.Equal(t, "ssh", opts.Name)
 		assert.Equal(t, []string{
-			"-o", "StrictHostKeyChecking=no",
-			"-o", "UserKnownHostsFile=/dev/null",
+			"-o", "StrictHostKeyChecking=accept-new",
 			"-o", "IdentitiesOnly=yes",
 			"-o", "NumberOfPasswordPrompts=0",
 			"-p", "22",
@@ -94,8 +93,7 @@ func TestSSHClientExecuteCommandUsesTimeoutAndRedactsCommandOutputOnFailure(t *t
 		assert.Equal(t, defaultSSHCommandTimeout, opts.Timeout)
 		assert.Equal(t, "ssh", opts.Name)
 		assert.Equal(t, []string{
-			"-o", "StrictHostKeyChecking=no",
-			"-o", "UserKnownHostsFile=/dev/null",
+			"-o", "StrictHostKeyChecking=accept-new",
 			"-o", "IdentitiesOnly=yes",
 			"-o", "NumberOfPasswordPrompts=0",
 			"-p", "2222",

--- a/cmd/homeops-cli/internal/talos/factory.go
+++ b/cmd/homeops-cli/internal/talos/factory.go
@@ -373,8 +373,8 @@ func (fc *FactoryClient) checkCache(req ISOGenerationRequest) (*ISOInfo, bool) {
 
 // cacheISOInfo caches ISO information
 func (fc *FactoryClient) cacheISOInfo(isoInfo *ISOInfo) error {
-	// Ensure cache directory exists
-	if err := os.MkdirAll(fc.cacheDir, 0755); err != nil {
+	// Ensure cache directory exists (owner-only, least privilege)
+	if err := os.MkdirAll(fc.cacheDir, 0700); err != nil {
 		return fmt.Errorf("failed to create cache directory: %w", err)
 	}
 
@@ -387,7 +387,7 @@ func (fc *FactoryClient) cacheISOInfo(isoInfo *ISOInfo) error {
 		return fmt.Errorf("failed to marshal ISO info: %w", err)
 	}
 
-	if err := os.WriteFile(isoInfo.CacheFile, data, 0644); err != nil {
+	if err := os.WriteFile(isoInfo.CacheFile, data, 0600); err != nil {
 		return fmt.Errorf("failed to write cache file: %w", err)
 	}
 

--- a/cmd/homeops-cli/internal/truenas/client.go
+++ b/cmd/homeops-cli/internal/truenas/client.go
@@ -102,7 +102,10 @@ func (c *WorkingClient) Connect() error {
 		MaxDelay:  8 * time.Second,
 		Sleep:     connectRetrySleep,
 	}, func() error {
-		client, err := truenas_api.NewClient(serverURL, !c.useSSL) // tlsSkipVerify is opposite of useSSL
+		// The second parameter is verifySSL (false sets InsecureSkipVerify in
+		// the library) — a previous inversion here disabled TLS verification
+		// on every wss connection. Verify whenever we dial over SSL.
+		client, err := truenas_api.NewClient(serverURL, c.useSSL)
 		if err != nil {
 			return fmt.Errorf("failed to create TrueNAS client: %w", err)
 		}

--- a/cmd/homeops-cli/internal/ui/prompts.go
+++ b/cmd/homeops-cli/internal/ui/prompts.go
@@ -22,6 +22,16 @@ func isInteractiveDisabled() bool {
 	return os.Getenv(constants.EnvHomeOpsNoInteract) == "1"
 }
 
+// assumeYes, when enabled via the global --yes flag, makes Confirm answer every
+// confirmation prompt affirmatively without blocking on user input.
+var assumeYes = false
+
+// SetAssumeYes toggles automatic confirmation for all Confirm prompts.
+// Wired to the root command's --yes/-y flag.
+func SetAssumeYes(v bool) {
+	assumeYes = v
+}
+
 // IsCancellation checks if an error is from user cancellation (Ctrl+C)
 func IsCancellation(err error) bool {
 	if err == nil {
@@ -44,6 +54,11 @@ type StyleOptions struct {
 // Returns true if the user confirms, false otherwise
 // Gracefully falls back to basic fmt.Scanln if gum is unavailable
 func Confirm(message string, defaultYes bool) (bool, error) {
+	if assumeYes {
+		// Leave an audit trail of what was auto-confirmed.
+		fmt.Fprintf(os.Stderr, "%s yes (--yes)\n", message)
+		return true, nil
+	}
 	if !isGumAvailable() || isInteractiveDisabled() {
 		return confirmBasic(message, defaultYes)
 	}

--- a/cmd/homeops-cli/internal/vsphere/client.go
+++ b/cmd/homeops-cli/internal/vsphere/client.go
@@ -615,7 +615,7 @@ func GetVMNames() ([]string, error) {
 	}
 
 	// Create vSphere client and connect
-	client, err := newClientWithConnectFn(host, username, password, true)
+	client, err := newClientWithConnectFn(host, username, password, common.EnvBool(constants.EnvVSphereInsecure, false))
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to vSphere: %w", err)
 	}
@@ -668,7 +668,7 @@ func NewESXiSSHClient(host, username string) (*ESXiSSHClient, error) {
 	}
 	_ = keyFile.Close()
 
-	logger.Debug("ESXi SSH key written to %s", keyFile.Name())
+	logger.Debug("ESXi SSH key written to temporary file")
 
 	return &ESXiSSHClient{
 		host:     host,
@@ -691,8 +691,9 @@ func (c *ESXiSSHClient) ExecuteCommand(command string) (string, error) {
 	c.logger.Debug("Executing ESXi command: %s", command)
 
 	args := []string{
-		"-o", "StrictHostKeyChecking=no",
-		"-o", "UserKnownHostsFile=/dev/null",
+		// Trust-on-first-use: record the host key on first connect, then
+		// refuse to connect if it ever changes (MITM protection).
+		"-o", "StrictHostKeyChecking=accept-new",
 		"-o", "IdentitiesOnly=yes",
 		"-i", c.keyFile,
 		fmt.Sprintf("%s@%s", c.username, c.host),

--- a/cmd/homeops-cli/internal/vsphere/client_helpers_test.go
+++ b/cmd/homeops-cli/internal/vsphere/client_helpers_test.go
@@ -323,7 +323,8 @@ func TestGetVMNamesWithSeams(t *testing.T) {
 		assert.Equal(t, "env-host", host)
 		assert.Equal(t, "env-user", username)
 		assert.Equal(t, "env-pass", password)
-		assert.True(t, insecure)
+		// TLS verification is the default; insecure requires VSPHERE_INSECURE=true.
+		assert.False(t, insecure)
 		return &Client{}, nil
 	}
 	listVMNamesFn = func(client *Client) ([]string, error) {

--- a/cmd/homeops-cli/internal/vsphere/vm_manager.go
+++ b/cmd/homeops-cli/internal/vsphere/vm_manager.go
@@ -1,0 +1,132 @@
+package vsphere
+
+import (
+	"fmt"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+
+	"homeops-cli/internal/common"
+	"homeops-cli/internal/provider"
+)
+
+// vmClient is the slice of Client that VMManager composes over; narrow so
+// tests can fake it.
+type vmClient interface {
+	ListVMs() ([]*object.VirtualMachine, error)
+	FindVM(name string) (*object.VirtualMachine, error)
+	GetVMInfo(vm *object.VirtualMachine) (*mo.VirtualMachine, error)
+	PowerOnVM(vm *object.VirtualMachine) error
+	PowerOffVM(vm *object.VirtualMachine) error
+	DeleteVM(vm *object.VirtualMachine) error
+	Close() error
+}
+
+// VMManager is the name-addressed lifecycle wrapper around Client. It owns
+// the find-by-name + act composition that command code previously repeated
+// per operation, and implements provider.VMLifecycle like the Proxmox and
+// TrueNAS managers do.
+type VMManager struct {
+	client vmClient
+	logger *common.ColorLogger
+}
+
+var _ provider.VMLifecycle = (*VMManager)(nil)
+
+// NewVMManager connects to vSphere/ESXi and returns a name-addressed manager.
+func NewVMManager(host, username, password string, insecure bool) (*VMManager, error) {
+	client, err := newClientWithConnectFn(host, username, password, insecure)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to vSphere: %w", err)
+	}
+	return &VMManager{client: client, logger: common.NewColorLogger()}, nil
+}
+
+// Close logs out of the vSphere session.
+func (m *VMManager) Close() error {
+	return m.client.Close()
+}
+
+// ListVMs prints the inventory of VMs.
+func (m *VMManager) ListVMs() error {
+	vms, err := m.client.ListVMs()
+	if err != nil {
+		return fmt.Errorf("failed to list VMs: %w", err)
+	}
+
+	fmt.Println("\nVMs on vSphere:")
+	fmt.Println("================")
+	for _, vm := range vms {
+		fmt.Printf("- %s\n", vm.Name())
+	}
+	fmt.Printf("\nTotal: %d VMs\n", len(vms))
+	return nil
+}
+
+// StartVM powers on the named VM.
+func (m *VMManager) StartVM(name string) error {
+	m.logger.Info("Powering on vSphere/ESXi VM: %s", name)
+	vm, err := m.client.FindVM(name)
+	if err != nil {
+		return fmt.Errorf("failed to find VM %s: %w", name, err)
+	}
+	if err := m.client.PowerOnVM(vm); err != nil {
+		return fmt.Errorf("failed to power on VM %s: %w", name, err)
+	}
+	m.logger.Success("VM %s powered on successfully!", name)
+	return nil
+}
+
+// StopVM powers off the named VM. vSphere's PowerOffVM is already a hard
+// power-off, so the force flag carries no extra meaning here.
+func (m *VMManager) StopVM(name string, _ bool) error {
+	m.logger.Info("Powering off vSphere/ESXi VM: %s", name)
+	vm, err := m.client.FindVM(name)
+	if err != nil {
+		return fmt.Errorf("failed to find VM %s: %w", name, err)
+	}
+	if err := m.client.PowerOffVM(vm); err != nil {
+		return fmt.Errorf("failed to power off VM %s: %w", name, err)
+	}
+	m.logger.Success("VM %s powered off successfully!", name)
+	return nil
+}
+
+// DeleteVM destroys the named VM.
+func (m *VMManager) DeleteVM(name string) error {
+	m.logger.Info("Starting vSphere/ESXi VM deletion for: %s", name)
+	vm, err := m.client.FindVM(name)
+	if err != nil {
+		return fmt.Errorf("failed to find VM %s: %w", name, err)
+	}
+	m.logger.Info("Found VM: %s", name)
+	if err := m.client.DeleteVM(vm); err != nil {
+		return fmt.Errorf("failed to delete VM %s: %w", name, err)
+	}
+	m.logger.Success("VM %s deleted successfully!", name)
+	return nil
+}
+
+// GetVMInfo prints detailed information for the named VM.
+func (m *VMManager) GetVMInfo(name string) error {
+	vm, err := m.client.FindVM(name)
+	if err != nil {
+		return fmt.Errorf("failed to find VM %s: %w", name, err)
+	}
+	vmInfo, err := m.client.GetVMInfo(vm)
+	if err != nil {
+		return fmt.Errorf("failed to get VM info for %s: %w", name, err)
+	}
+
+	m.logger.Info("VM Information for: %s", name)
+	m.logger.Info("  Power State: %s", vmInfo.Runtime.PowerState)
+	m.logger.Info("  Guest OS: %s", vmInfo.Config.GuestFullName)
+	m.logger.Info("  CPUs: %d", vmInfo.Config.Hardware.NumCPU)
+	m.logger.Info("  Memory: %d MB", vmInfo.Config.Hardware.MemoryMB)
+	m.logger.Info("  UUID: %s", vmInfo.Config.Uuid)
+
+	if vmInfo.Guest != nil && vmInfo.Guest.IpAddress != "" {
+		m.logger.Info("  IP Address: %s", vmInfo.Guest.IpAddress)
+	}
+	return nil
+}

--- a/cmd/homeops-cli/internal/vsphere/vm_manager_test.go
+++ b/cmd/homeops-cli/internal/vsphere/vm_manager_test.go
@@ -1,0 +1,129 @@
+package vsphere
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+
+	"homeops-cli/internal/common"
+)
+
+type fakeVMClient struct {
+	foundNames   []string
+	findErr      error
+	poweredOn    int
+	poweredOff   int
+	deleted      int
+	listCount    int
+	closeCalls   int
+	infoResponse *mo.VirtualMachine
+}
+
+func (f *fakeVMClient) ListVMs() ([]*object.VirtualMachine, error) {
+	f.listCount++
+	return nil, nil
+}
+
+func (f *fakeVMClient) FindVM(name string) (*object.VirtualMachine, error) {
+	if f.findErr != nil {
+		return nil, f.findErr
+	}
+	f.foundNames = append(f.foundNames, name)
+	return nil, nil
+}
+
+func (f *fakeVMClient) GetVMInfo(*object.VirtualMachine) (*mo.VirtualMachine, error) {
+	return f.infoResponse, nil
+}
+
+func (f *fakeVMClient) PowerOnVM(*object.VirtualMachine) error {
+	f.poweredOn++
+	return nil
+}
+
+func (f *fakeVMClient) PowerOffVM(*object.VirtualMachine) error {
+	f.poweredOff++
+	return nil
+}
+
+func (f *fakeVMClient) DeleteVM(*object.VirtualMachine) error {
+	f.deleted++
+	return nil
+}
+
+func (f *fakeVMClient) Close() error {
+	f.closeCalls++
+	return nil
+}
+
+func newTestVMManager(client vmClient) *VMManager {
+	return &VMManager{client: client, logger: common.NewColorLogger()}
+}
+
+func TestVMManagerLifecycleComposition(t *testing.T) {
+	client := &fakeVMClient{
+		infoResponse: &mo.VirtualMachine{
+			Runtime: types.VirtualMachineRuntimeInfo{PowerState: types.VirtualMachinePowerStatePoweredOn},
+			Config: &types.VirtualMachineConfigInfo{
+				GuestFullName: "Talos Linux",
+				Uuid:          "vm-uuid",
+				Hardware:      types.VirtualHardware{NumCPU: 4, MemoryMB: 8192},
+			},
+			Guest: &types.GuestInfo{IpAddress: "10.0.0.99"},
+		},
+	}
+	manager := newTestVMManager(client)
+
+	require.NoError(t, manager.ListVMs())
+	require.NoError(t, manager.StartVM("esx-vm"))
+	require.NoError(t, manager.StopVM("esx-vm", true))
+	require.NoError(t, manager.DeleteVM("esx-vm"))
+	require.NoError(t, manager.GetVMInfo("esx-vm"))
+	require.NoError(t, manager.Close())
+
+	assert.Equal(t, 1, client.listCount)
+	assert.Equal(t, []string{"esx-vm", "esx-vm", "esx-vm", "esx-vm"}, client.foundNames)
+	assert.Equal(t, 1, client.poweredOn)
+	assert.Equal(t, 1, client.poweredOff)
+	assert.Equal(t, 1, client.deleted)
+	assert.Equal(t, 1, client.closeCalls)
+}
+
+func TestVMManagerFindErrorsAreWrapped(t *testing.T) {
+	client := &fakeVMClient{findErr: errors.New("no such vm")}
+	manager := newTestVMManager(client)
+
+	for _, op := range []struct {
+		name string
+		run  func() error
+	}{
+		{"start", func() error { return manager.StartVM("missing") }},
+		{"stop", func() error { return manager.StopVM("missing", false) }},
+		{"delete", func() error { return manager.DeleteVM("missing") }},
+		{"info", func() error { return manager.GetVMInfo("missing") }},
+	} {
+		err := op.run()
+		require.Error(t, err, op.name)
+		assert.Contains(t, err.Error(), fmt.Sprintf("failed to find VM %s", "missing"), op.name)
+		assert.Contains(t, err.Error(), "no such vm", op.name)
+	}
+}
+
+func TestNewVMManagerConnectError(t *testing.T) {
+	original := newClientWithConnectFn
+	t.Cleanup(func() { newClientWithConnectFn = original })
+
+	newClientWithConnectFn = func(host, username, password string, insecure bool) (*Client, error) {
+		return nil, errors.New("dial failed")
+	}
+
+	_, err := NewVMManager("esxi.local", "root", "secret", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to connect to vSphere")
+}

--- a/cmd/homeops-cli/main.go
+++ b/cmd/homeops-cli/main.go
@@ -29,6 +29,7 @@ var (
 	commit           = "none"
 	date             = "unknown"
 	logLevel         string
+	assumeYes        bool
 	chooseFn                   = ui.Choose
 	signalNotifyFn             = signal.Notify
 	executeRootCmdFn           = func(cmd *cobra.Command) error { return cmd.Execute() }
@@ -75,15 +76,21 @@ VolSync backups, and more.`,
 			if logLevel != "" {
 				common.SetGlobalLogLevel(logLevel)
 			}
+			ui.SetAssumeYes(assumeYes)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// If no subcommand provided, show interactive menu
+			// Only launch the interactive menu on a real terminal; when stdin is
+			// piped or redirected (scripts, CI), print help instead of blocking.
+			if !stdinIsTerminal() {
+				return cmd.Help()
+			}
 			return showInteractiveMenu(cmd)
 		},
 	}
 
 	// Add global flags
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "", "Set log level (debug, info, warn, error)")
+	rootCmd.PersistentFlags().BoolVarP(&assumeYes, "yes", "y", false, "Assume yes for all confirmation prompts (non-interactive)")
 
 	// Set global environment variables
 	setEnvironment()
@@ -106,6 +113,16 @@ VolSync backups, and more.`,
 	rootCmd.SetContext(ctx)
 
 	return rootCmd
+}
+
+// stdinIsTerminal reports whether stdin is attached to a terminal (vs a pipe
+// or redirect), so interactive prompts are only offered where a user can type.
+func stdinIsTerminal() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
 }
 
 func showInteractiveMenu(rootCmd *cobra.Command) error {


### PR DESCRIPTION
Two hardening/refactor arcs for the CLI (no kubernetes/ manifest changes — Flux unaffected).

## Arc #19 — security + UX
- SSH host-key policy: `StrictHostKeyChecking=no` + null known_hosts → `accept-new` (TOFU) for TrueNAS + ESXi SSH clients
- Two residual hardcoded `insecure=true` vSphere TLS call sites missed by #18 now honor `VSPHERE_INSECURE` (verify by default)
- Owner-only perms: kubeconfig dest dir 0700, Talos factory ISO cache 0700/0600; stop logging ESXi key temp path
- Global `--yes`/`-y` flag auto-confirms destructive-op prompts (with stderr audit line)
- Bare `homeops-cli` with piped stdin prints help instead of hanging on the interactive menu
- Bootstrap preflight checks run concurrently (1Password auth + config render stay serial)

## Arc #20 — TLS fix + architecture
- **TrueNAS websocket TLS was silently unverified**: library param is `verifySSL`, code passed `!useSSL`. Fixed; paired with 1Password `TRUENAS_HOST` flip to `nas01.achva.casa` (cert has no IP SAN)
- `internal/provider.VMLifecycle`: shared hypervisor lifecycle contract; vsphere gains name-addressed `VMManager`; six per-action provider switches + twelve wrapper funcs collapse into one factory with a single test seam (net −250 LOC)
- `internal/errors` trimmed 372→75 lines (zero-caller constructors, Wrap* helpers, fluent context chain, never-displayed user-message catalog)
- Perf collector finally surfaced: `LogReport` at debug level at all collector sites

Tested: full `go build`/`go vet`/`go test ./...` on go 1.26 — green except 3 pre-existing env-dependent failures present identically on clean main.