### PR TITLE
homeops-cli: cancellation fix + hardening/UX arc #21

### DIFF
--- a/cmd/homeops-cli/cmd/bootstrap/bootstrap.go
+++ b/cmd/homeops-cli/cmd/bootstrap/bootstrap.go
@@ -1394,25 +1394,29 @@ func renderMachineConfigFromEmbedded(baseTemplate, patchTemplate, _ string, logg
 
 // mergeConfigsWithTalosctl merges base and patch configs using talosctl (onedr0p approach)
 func mergeConfigsWithTalosctl(baseConfig, patchConfig []byte) ([]byte, error) {
-	// Create temporary files for talosctl processing
-	baseFile, err := os.CreateTemp(bootstrapTalosTempDir, "talos-base-*.yaml")
+	// The configs have 1Password references already resolved, so keep them in
+	// a private 0700 directory for the duration of the merge instead of
+	// loose files in the shared temp root.
+	mergeDir, err := os.MkdirTemp(bootstrapTalosTempDir, "talos-merge-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create config merge temp dir: %w", err)
+	}
+	defer func() {
+		_ = os.RemoveAll(mergeDir) // Ignore cleanup errors
+	}()
+
+	baseFile, err := os.CreateTemp(mergeDir, "talos-base-*.yaml")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create base config temp file: %w", err)
 	}
 	defer func() {
-		_ = os.Remove(baseFile.Name()) // Ignore cleanup errors
-	}()
-	defer func() {
 		_ = baseFile.Close() // Ignore cleanup errors
 	}()
 
-	patchFile, err := os.CreateTemp(bootstrapTalosTempDir, "talos-patch-*.yaml")
+	patchFile, err := os.CreateTemp(mergeDir, "talos-patch-*.yaml")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create patch config temp file: %w", err)
 	}
-	defer func() {
-		_ = os.Remove(patchFile.Name()) // Ignore cleanup errors
-	}()
 	defer func() {
 		_ = patchFile.Close() // Ignore cleanup errors
 	}()
@@ -1628,9 +1632,9 @@ func fetchKubeconfig(config *BootstrapConfig, logger *common.ColorLogger) error 
 
 	logger.Debug("Fetching kubeconfig from controller %s", controller)
 
-	// Ensure directory exists for kubeconfig
+	// Ensure directory exists for kubeconfig (owner-only: holds credentials)
 	kubeconfigDir := filepath.Dir(config.KubeConfig)
-	if err := os.MkdirAll(kubeconfigDir, 0755); err != nil {
+	if err := os.MkdirAll(kubeconfigDir, 0700); err != nil {
 		return fmt.Errorf("failed to create kubeconfig directory %s: %w", kubeconfigDir, err)
 	}
 

--- a/cmd/homeops-cli/cmd/completion/completion.go
+++ b/cmd/homeops-cli/cmd/completion/completion.go
@@ -57,20 +57,24 @@ PowerShell:
 		DisableFlagsInUseLine: true,
 		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
 		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
 			switch args[0] {
 			case "bash":
-				_ = cmd.Root().GenBashCompletion(os.Stdout)
+				err = cmd.Root().GenBashCompletion(os.Stdout)
 			case "zsh":
-				_ = cmd.Root().GenZshCompletion(os.Stdout)
+				err = cmd.Root().GenZshCompletion(os.Stdout)
 			case "fish":
-				_ = cmd.Root().GenFishCompletion(os.Stdout, true)
+				err = cmd.Root().GenFishCompletion(os.Stdout, true)
 			case "powershell":
-				_ = cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+				err = cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
 			default:
-				fmt.Fprintf(os.Stderr, "Unsupported shell type %q\n", args[0])
-				os.Exit(1)
+				return fmt.Errorf("unsupported shell type %q", args[0])
 			}
+			if err != nil {
+				return fmt.Errorf("failed to generate %s completion: %w", args[0], err)
+			}
+			return nil
 		},
 	}
 

--- a/cmd/homeops-cli/cmd/flatcar/flatcar.go
+++ b/cmd/homeops-cli/cmd/flatcar/flatcar.go
@@ -903,6 +903,9 @@ func newGenKubeadmCommand() *cobra.Command {
 				}
 				fmt.Fprintln(cmd.OutOrStdout(), out)
 			case "join":
+				if err := flatcar.ValidateJoinMaterial(token, caCertHash, certKey); err != nil {
+					return err
+				}
 				env.CertificateKey = certKey
 				env.BootstrapToken = token
 				env.CACertHash = caCertHash

--- a/cmd/homeops-cli/cmd/flatcar/flatcar_test.go
+++ b/cmd/homeops-cli/cmd/flatcar/flatcar_test.go
@@ -274,15 +274,29 @@ func TestGenKubeadmCommandJoin(t *testing.T) {
 		return "kind: JoinConfiguration", nil
 	}
 
+	// Join material must pass flatcar.ValidateJoinMaterial format checks.
+	validToken := "abcdef.0123456789abcdef"
+	validHash := "sha256:" + strings.Repeat("ab", 32)
+	validCertKey := strings.Repeat("cd", 32)
+
 	cmd := newGenKubeadmCommand()
 	out := &bytes.Buffer{}
 	cmd.SetOut(out)
-	cmd.SetArgs([]string{"--node", "k8s-1", "--mode", "join", "--cert-key", "k", "--token", "t", "--ca-cert-hash", "h"})
+	cmd.SetArgs([]string{"--node", "k8s-1", "--mode", "join", "--cert-key", validCertKey, "--token", validToken, "--ca-cert-hash", validHash})
 	require.NoError(t, cmd.Execute())
 	assert.Contains(t, out.String(), "JoinConfiguration")
-	assert.Equal(t, "k", captured.CertificateKey)
-	assert.Equal(t, "t", captured.BootstrapToken)
-	assert.Equal(t, "h", captured.CACertHash)
+	assert.Equal(t, validCertKey, captured.CertificateKey)
+	assert.Equal(t, validToken, captured.BootstrapToken)
+	assert.Equal(t, validHash, captured.CACertHash)
+
+	// Malformed material is rejected before rendering.
+	badCmd := newGenKubeadmCommand()
+	badCmd.SetOut(&bytes.Buffer{})
+	badCmd.SetErr(&bytes.Buffer{})
+	badCmd.SetArgs([]string{"--node", "k8s-1", "--mode", "join", "--token", "nope", "--ca-cert-hash", validHash})
+	err := badCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --token")
 }
 
 func TestDeployVMDryRun(t *testing.T) {

--- a/cmd/homeops-cli/cmd/volsync/volsync.go
+++ b/cmd/homeops-cli/cmd/volsync/volsync.go
@@ -360,20 +360,28 @@ func setAllVolsyncResourcesSuspended(namespace string, suspend bool) error {
 	completedState := boolWord(suspend, "suspended", "resumed")
 	resourceKinds := []string{"replicationsource", "replicationdestination"}
 
+	var failures []string
 	for _, kind := range resourceKinds {
 		names, err := listVolsyncResources(namespace, kind)
 		if err != nil {
 			logger.Warn("Failed to list %ss: %v", resourceDisplayName(kind), err)
+			failures = append(failures, fmt.Sprintf("list %ss", resourceDisplayName(kind)))
 			continue
 		}
 
 		for _, name := range names {
 			if err := patchVolsyncResource(namespace, kind, name, suspend); err != nil {
 				logger.Error("Failed to %s %s %s: %v", desiredState, resourceDisplayName(kind), name, err)
+				failures = append(failures, fmt.Sprintf("%s/%s", kind, name))
 			} else {
 				logger.Info("%s %s %s", capitalize(completedState), resourceDisplayName(kind), name)
 			}
 		}
+	}
+
+	if len(failures) > 0 {
+		return fmt.Errorf("failed to %s %d VolSync resource(s) in namespace %s: %s",
+			desiredState, len(failures), namespace, strings.Join(failures, ", "))
 	}
 
 	logger.Success("%s all VolSync resources in namespace %s", capitalize(completedState), namespace)
@@ -565,13 +573,21 @@ func fetchReplicationSourceNames(namespace string) ([]string, error) {
 // waitForJobToAppear polls kubectl until the named Job exists in the namespace.
 // Returns an error if the job does not appear within `timeout`.
 func waitForJobToAppear(namespace, jobName string, timeout time.Duration) error {
+	logger := common.NewColorLogger()
 	start := time.Now()
+	lastProgress := start
 	for {
 		if err := commandRunFn("kubectl", "--namespace", namespace, "get", fmt.Sprintf("job/%s", jobName)); err == nil {
 			return nil
 		}
 		if time.Since(start) >= timeout {
 			return fmt.Errorf("job %s did not appear within %v", jobName, timeout)
+		}
+		// Heartbeat so long waits don't look like a hang.
+		if time.Since(lastProgress) >= 30*time.Second {
+			logger.Info("Still waiting for job %s to appear (elapsed %v, timeout %v)...",
+				jobName, time.Since(start).Round(time.Second), timeout)
+			lastProgress = time.Now()
 		}
 		volsyncSleep(5 * time.Second)
 	}
@@ -1042,8 +1058,10 @@ func restoreApp(namespace, app, previous string, force bool, restoreTimeout time
 	jobName := fmt.Sprintf("volsync-dst-%s-manual", app)
 	logger.Info("Waiting for restore job %s to complete...", jobName)
 
-	// Wait for job to appear with timeout (use 1/4 of restoreTimeout or 5 minutes max for job appearance)
-	jobAppearTimeout := min(restoreTimeout/4, 5*time.Minute)
+	// Wait for job to appear with timeout: 1/4 of restoreTimeout, capped at
+	// 5 minutes, but never below 30s (small --timeout values would otherwise
+	// abort before slow clusters can even schedule the job).
+	jobAppearTimeout := max(min(restoreTimeout/4, 5*time.Minute), 30*time.Second)
 	if err := waitForJobToAppear(namespace, jobName, jobAppearTimeout); err != nil {
 		return fmt.Errorf("restore %w", err)
 	}

--- a/cmd/homeops-cli/cmd/workstation/workstation.go
+++ b/cmd/homeops-cli/cmd/workstation/workstation.go
@@ -3,6 +3,8 @@ package workstation
 import (
 	"archive/tar"
 	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -118,7 +120,8 @@ func installBrewPackages() error {
 		logger.Success("Homebrew packages already match the embedded Brewfile")
 		return nil
 	}
-	logger.Debug("brew bundle check reported changes needed: %s", strings.TrimSpace(string(checkOutput)))
+	// Surface what's missing at info level so users see why install runs.
+	logger.Info("Homebrew changes needed:\n%s", strings.TrimSpace(string(checkOutput)))
 
 	// Run brew bundle install with spinner
 	err = spinWithFunc("📦 Installing Homebrew packages", func() error {
@@ -229,6 +232,12 @@ func installKrew() error {
 		return fmt.Errorf("failed to download krew archive: %w", err)
 	}
 
+	// Verify integrity against the published .sha256 before extracting and
+	// executing anything from the archive.
+	if err := verifyFileSHA256(archivePath, archiveURL+".sha256"); err != nil {
+		return fmt.Errorf("krew archive integrity check failed: %w", err)
+	}
+
 	if err := extractTarGz(archivePath, tempDir); err != nil {
 		return fmt.Errorf("failed to extract krew archive: %w", err)
 	}
@@ -302,6 +311,53 @@ func normalizeKrewArch(goarch string) (string, error) {
 	default:
 		return "", fmt.Errorf("unsupported architecture for Krew: %s", goarch)
 	}
+}
+
+// verifyFileSHA256 downloads the expected digest from checksumURL (a file
+// whose first whitespace-separated field is the hex SHA-256) and compares it
+// against the actual digest of the file at path.
+func verifyFileSHA256(path, checksumURL string) error {
+	resp, err := httpGetFunc(checksumURL)
+	if err != nil {
+		return fmt.Errorf("failed to download checksum: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected HTTP status %s fetching checksum", resp.Status)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if err != nil {
+		return fmt.Errorf("failed to read checksum: %w", err)
+	}
+	fields := strings.Fields(string(body))
+	if len(fields) == 0 {
+		return fmt.Errorf("checksum file is empty")
+	}
+	expected := strings.ToLower(fields[0])
+	if len(expected) != sha256.Size*2 {
+		return fmt.Errorf("checksum file does not contain a SHA-256 digest")
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return err
+	}
+	actual := hex.EncodeToString(h.Sum(nil))
+
+	if actual != expected {
+		return fmt.Errorf("SHA-256 mismatch: expected %s, got %s", expected, actual)
+	}
+	return nil
 }
 
 func downloadFile(url, destination string) error {

--- a/cmd/homeops-cli/cmd/workstation/workstation_test.go
+++ b/cmd/homeops-cli/cmd/workstation/workstation_test.go
@@ -4,6 +4,8 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -456,7 +458,68 @@ func TestKrewDownloadInfo(t *testing.T) {
 	assert.Equal(t, "https://example.test/krew/krew-linux_amd64.tar.gz", url)
 }
 
+// skipIfTempNoexec skips tests that need to execute binaries out of the
+// system temp dir (mounted noexec on some hardened hosts).
+func skipIfTempNoexec(t *testing.T) {
+	t.Helper()
+	probe, err := os.CreateTemp("", "execprobe-*.sh")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(probe.Name()) }()
+	_, err = probe.WriteString("#!/bin/sh\nexit 0\n")
+	require.NoError(t, err)
+	require.NoError(t, probe.Close())
+	require.NoError(t, os.Chmod(probe.Name(), 0o700))
+	if err := exec.Command(probe.Name()).Run(); err != nil {
+		t.Skipf("system temp dir is not executable (noexec mount?): %v", err)
+	}
+}
+
 func TestInstallKrew(t *testing.T) {
+	skipIfTempNoexec(t)
+
+	executableName := "krew-linux_amd64"
+	archiveBytes := buildKrewArchive(t, executableName)
+	archiveSum := sha256.Sum256(archiveBytes)
+	checksumBody := hex.EncodeToString(archiveSum[:]) + "  " + executableName + ".tar.gz\n"
+
+	oldOS := runtimeGOOS
+	oldArch := runtimeGOARCH
+	oldBaseURL := krewDownloadBaseURL
+	oldHTTPGet := httpGetFunc
+	t.Cleanup(func() {
+		runtimeGOOS = oldOS
+		runtimeGOARCH = oldArch
+		krewDownloadBaseURL = oldBaseURL
+		httpGetFunc = oldHTTPGet
+	})
+
+	runtimeGOOS = "linux"
+	runtimeGOARCH = "amd64"
+	krewDownloadBaseURL = "https://example.test/krew"
+	httpGetFunc = func(url string) (*http.Response, error) {
+		switch {
+		case strings.HasSuffix(url, executableName+".tar.gz"):
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Body:       io.NopCloser(bytes.NewReader(archiveBytes)),
+			}, nil
+		case strings.HasSuffix(url, executableName+".tar.gz.sha256"):
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Body:       io.NopCloser(strings.NewReader(checksumBody)),
+			}, nil
+		default:
+			t.Fatalf("unexpected download URL: %s", url)
+			return nil, nil
+		}
+	}
+
+	require.NoError(t, installKrew())
+}
+
+func TestInstallKrewRejectsChecksumMismatch(t *testing.T) {
 	executableName := "krew-linux_amd64"
 	archiveBytes := buildKrewArchive(t, executableName)
 
@@ -475,7 +538,13 @@ func TestInstallKrew(t *testing.T) {
 	runtimeGOARCH = "amd64"
 	krewDownloadBaseURL = "https://example.test/krew"
 	httpGetFunc = func(url string) (*http.Response, error) {
-		require.True(t, strings.HasSuffix(url, executableName+".tar.gz"))
+		if strings.HasSuffix(url, ".sha256") {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Body:       io.NopCloser(strings.NewReader(strings.Repeat("00", 32) + "  whatever\n")),
+			}, nil
+		}
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Status:     "200 OK",
@@ -483,7 +552,9 @@ func TestInstallKrew(t *testing.T) {
 		}, nil
 	}
 
-	require.NoError(t, installKrew())
+	err := installKrew()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "integrity check failed")
 }
 
 func TestExtractTarGzRejectsTraversal(t *testing.T) {

--- a/cmd/homeops-cli/internal/common/command.go
+++ b/cmd/homeops-cli/internal/common/command.go
@@ -82,6 +82,10 @@ func RunCommand(ctx context.Context, opts CommandOptions) (CommandResult, error)
 	}
 
 	cmd := exec.CommandContext(runCtx, opts.Name, opts.Args...)
+	// After the context kills the process, force-close its I/O pipes so Wait
+	// can't be held hostage by orphaned grandchildren that inherited them
+	// (e.g. a shell's `sleep` child surviving the shell's SIGKILL).
+	cmd.WaitDelay = 3 * time.Second
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/cmd/homeops-cli/internal/common/logger.go
+++ b/cmd/homeops-cli/internal/common/logger.go
@@ -100,10 +100,11 @@ func Logger() *ColorLogger {
 		globalLogger = NewColorLogger()
 	})
 
-	// Update level in case it was changed
-	globalLogMu.RLock()
+	// Update level in case it was changed. Write lock: concurrent callers
+	// would otherwise race on the assignment.
+	globalLogMu.Lock()
 	globalLogger.Level = globalLogLevel
-	globalLogMu.RUnlock()
+	globalLogMu.Unlock()
 
 	return globalLogger
 }

--- a/cmd/homeops-cli/internal/flatcar/kubeadm.go
+++ b/cmd/homeops-cli/internal/flatcar/kubeadm.go
@@ -341,7 +341,29 @@ var (
 	tokenRe = regexp.MustCompile(`--token\s+([a-z0-9]{6}\.[a-z0-9]{16})`)
 	// The certificate key is printed on its own line after the upload-certs notice.
 	certKeyRe = regexp.MustCompile(`(?m)^\s*([0-9a-f]{64})\s*$`)
+
+	// Strict whole-string forms of the above, for validating user-supplied
+	// join material before it is rendered into a join configuration.
+	strictTokenRe      = regexp.MustCompile(`^[a-z0-9]{6}\.[a-z0-9]{16}$`)
+	strictCACertHashRe = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	strictCertKeyRe    = regexp.MustCompile(`^[0-9a-f]{64}$`)
 )
+
+// ValidateJoinMaterial checks user-supplied kubeadm join material against the
+// formats kubeadm emits. token and caCertHash are required; certKey is
+// optional (worker joins) but must be well-formed when present.
+func ValidateJoinMaterial(token, caCertHash, certKey string) error {
+	if !strictTokenRe.MatchString(token) {
+		return fmt.Errorf("invalid --token: want kubeadm format like abcdef.0123456789abcdef")
+	}
+	if !strictCACertHashRe.MatchString(caCertHash) {
+		return fmt.Errorf("invalid --ca-cert-hash: want sha256:<64 hex chars>")
+	}
+	if certKey != "" && !strictCertKeyRe.MatchString(certKey) {
+		return fmt.Errorf("invalid --certificate-key: want 64 hex chars")
+	}
+	return nil
+}
 
 // ParseKubeadmInitOutput extracts the bootstrap token, CA cert hash and (if
 // present) the control-plane certificate key from `kubeadm init` stdout.

--- a/cmd/homeops-cli/internal/ui/prompts.go
+++ b/cmd/homeops-cli/internal/ui/prompts.go
@@ -353,7 +353,8 @@ done
 
 	scriptPath := tmpFile.Name()
 	_ = tmpFile.Close()
-	if err := os.Chmod(scriptPath, 0o755); err != nil {
+	// Owner-only: nothing else needs to read or execute the spinner script.
+	if err := os.Chmod(scriptPath, 0o700); err != nil {
 		_ = os.Remove(scriptPath)
 		return nil, nil, "", err
 	}


### PR DESCRIPTION
Third hardening arc on the CLI (no kubernetes/ manifest changes — Flux unaffected). Found via fresh three-agent audit of the less-covered packages (bootstrap, flatcar, volsync, workstation, completion, internal support).

## Real bug fix
- **Context cancellation could hang for the full child runtime**: `RunCommand`'s buffer-backed pipes kept `Wait()` blocked while orphaned grandchildren held them after the kill. `cmd.WaitDelay=3s` force-closes pipes post-kill. This was the actual cause of the three long-standing "environment-dependent" test failures — the suite is now fully green (and ~90s faster).

## Hardening
- workstation: krew archive SHA-256 verified against the published checksum before extract/exec (+ mismatch test)
- bootstrap: secret-resolved talos config merges now use a private 0700 temp dir; kubeconfig dest dir 0755→0700
- flatcar: `gen-kubeadm --mode join` validates token/ca-cert-hash/cert-key formats before rendering
- ui: spinner script 0700; logger singleton level sync takes the write lock

## UX/consistency
- volsync: suspend/resume-all returns an aggregated error instead of success-after-failures; restore job-appear timeout floored at 30s; heartbeat every 30s during silent waits
- completion: generation errors surfaced instead of silently discarded
- workstation: `brew bundle check` findings shown at info level

Tested: full `go build`/`go vet`/`go test ./...` green on go 1.26 — zero failures (previously 4 packages had failures).