### PR TITLE
fix(homeops-cli): repair internal/proxmox build against go-proxmox v0.7.1 API

### DIFF
--- a/cmd/homeops-cli/internal/proxmox/vm_manager.go
+++ b/cmd/homeops-cli/internal/proxmox/vm_manager.go
@@ -1189,13 +1189,30 @@ func formatVMInfo(name string, vmObj *proxmox.VirtualMachine) string {
 		config := vmObj.VirtualMachineConfig
 		fmt.Fprintln(&b, "\nConfiguration:")
 		fmt.Fprintf(&b, "  Name: %s\n", config.Name)
-		fmt.Fprintf(&b, "  Cores: %d\n", config.Cores)
-		fmt.Fprintf(&b, "  Sockets: %d\n", config.Sockets)
-		fmt.Fprintf(&b, "  BIOS: %s\n", config.Bios)
-		fmt.Fprintf(&b, "  SCSI HW: %s\n", config.SCSIHW)
+		fmt.Fprintf(&b, "  Cores: %d\n", derefInt(config.Cores))
+		fmt.Fprintf(&b, "  Sockets: %d\n", derefInt(config.Sockets))
+		fmt.Fprintf(&b, "  BIOS: %s\n", derefStr(config.Bios))
+		fmt.Fprintf(&b, "  SCSI HW: %s\n", derefStr(config.SCSIHW))
 	}
 
 	return b.String()
+}
+
+// derefInt / derefStr safely dereference go-proxmox's *int / *string config
+// fields (e.g. Cores, Sockets, Bios, SCSIHW), returning the zero value when the
+// pointer is nil so display formatting never prints a pointer address (#199).
+func derefInt(p *int) int {
+	if p == nil {
+		return 0
+	}
+	return *p
+}
+
+func derefStr(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
 }
 
 func (vm *VMManager) getVMHandle(name string) (vmHandle, error) {

--- a/cmd/homeops-cli/internal/proxmox/vm_manager_flow_test.go
+++ b/cmd/homeops-cli/internal/proxmox/vm_manager_flow_test.go
@@ -229,10 +229,10 @@ func TestVMManagerListAndInfoFormatting(t *testing.T) {
 				Uptime: 123,
 				VirtualMachineConfig: &proxmox.VirtualMachineConfig{
 					Name:    name,
-					Cores:   4,
-					Sockets: 1,
-					Bios:    "ovmf",
-					SCSIHW:  "virtio-scsi-single",
+					Cores:   intPtr(4),
+					Sockets: intPtr(1),
+					Bios:    strPtr("ovmf"),
+					SCSIHW:  strPtr("virtio-scsi-single"),
 				},
 			}, nil
 		},
@@ -248,6 +248,12 @@ func TestVMManagerListAndInfoFormatting(t *testing.T) {
 	assert.Contains(t, output, "VM Information for: cp-0")
 	assert.Contains(t, output, "SCSI HW: virtio-scsi-single")
 }
+
+// intPtr / strPtr return pointers to their argument. go-proxmox's
+// VirtualMachineConfig models Cores/Sockets as *int and Bios/SCSIHW as *string
+// so the PVE server default is preserved when a field is unset (#199).
+func intPtr(i int) *int       { return &i }
+func strPtr(s string) *string { return &s }
 
 func TestProxmoxFormattingHelpers(t *testing.T) {
 	assert.Equal(t, "No virtual machines found.\n", formatVMList(nil))

--- a/cmd/homeops-cli/internal/proxmox/vm_snapshot.go
+++ b/cmd/homeops-cli/internal/proxmox/vm_snapshot.go
@@ -62,7 +62,7 @@ func (vm *VMManager) RollbackVM(name, snapName string) error {
 	if err != nil {
 		return err
 	}
-	task, err := vmObj.SnapshotRollback(vm.client.Context(), snapName)
+	task, err := vmObj.Snapshot(snapName).Rollback(vm.client.Context())
 	if err != nil {
 		return fmt.Errorf("rollback VM %s to %s: %w", name, snapName, err)
 	}
@@ -79,7 +79,7 @@ func (vm *VMManager) DeleteVMSnapshot(name, snapName string) error {
 	if err != nil {
 		return err
 	}
-	task, err := vmObj.DeleteSnapshot(vm.client.Context(), snapName)
+	task, err := vmObj.Snapshot(snapName).Delete(vm.client.Context())
 	if err != nil {
 		return fmt.Errorf("delete snapshot %s of VM %s: %w", snapName, name, err)
 	}
@@ -104,7 +104,7 @@ func (vm *VMManager) CloneVM(name, newName string, newVMID int, full bool) error
 	}
 	opts := &proxmox.VirtualMachineCloneOptions{NewID: newVMID, Name: newName}
 	if full {
-		opts.Full = 1
+		opts.Full = true
 	}
 	id, task, err := vmObj.Clone(vm.client.Context(), opts)
 	if err != nil {


### PR DESCRIPTION
## Problem

`origin/main` does not `go build ./...` — `make build` fails on three pre-existing errors in `internal/proxmox/vm_snapshot.go`. The code calls go-proxmox APIs that don't exist in the pinned **v0.7.1**. (There is no Go build/test in CI, so this went unnoticed.)

```
vm_snapshot.go:65: vmObj.SnapshotRollback undefined
vm_snapshot.go:82: vmObj.DeleteSnapshot undefined
vm_snapshot.go:107: cannot use 1 (untyped int) as IntOrBool value
```

## Fix

- **Snapshot rollback/delete** moved onto a snapshot handle in v0.7.1: `VirtualMachine.SnapshotRollback/DeleteSnapshot(ctx, name)` → `VirtualMachine.Snapshot(name).Rollback(ctx)` / `.Delete(ctx)` (both still return `(*Task, error)`).
- **`VirtualMachineCloneOptions.Full`** is now `IntOrBool` (underlying `bool`): `opts.Full = 1` → `opts.Full = true`.

While fixing, `go vet` exposed a **latent display bug** in the same area: v0.7.1 models `VirtualMachineConfig.Cores/Sockets` as `*int` and `Bios/SCSIHW` as `*string` (#199), but `formatVMInfo` printed them with `%d`/`%s` — which renders the pointer address, not the value. Now dereferenced via nil-safe `derefInt`/`derefStr` helpers. The flow test's struct literal updated to set the pointer fields (`intPtr`/`strPtr`).

## Validation

- `make build` ✅
- `go vet ./...` ✅ (compiles every package incl. tests)
- `golangci-lint run ./...` → **0 issues**
- `go test -race -short ./...` ✅ (all packages pass)

## Follow-up (not in this PR)

This repo has **no Go build/test/lint CI** — only Flux-manifest + image checks — which is why a non-building `main` slipped through. Worth adding a `go build/vet/test` workflow so this can't recur.