### PR TITLE
fix(flatcar): kubelet imageGC thresholds below Ceph mon disk warn

### DIFF
--- a/cmd/homeops-cli/internal/templates/flatcar/kubeadm/init-config.yaml
+++ b/cmd/homeops-cli/internal/templates/flatcar/kubeadm/init-config.yaml
@@ -106,3 +106,9 @@ clusterDomain: cluster.local
 clusterDNS:
   - 10.43.0.10                        # CoreDNS Service clusterIP (verify vs coredns HR)
 maxPods: 250
+# The Rook Ceph mon shares this node's root/EPHEMERAL fs with the containerd image
+# store. kubelet's default imageGC high=85 lets the image cache grow until Ceph's
+# mon_data_avail_warn (30% avail / 70% used) flags MON_DISK_LOW on the busiest node.
+# Trim earlier so kubelet GCs unused images before Ceph complains.
+imageGCHighThresholdPercent: 60
+imageGCLowThresholdPercent: 50


### PR DESCRIPTION
## What
Sets `imageGCHighThresholdPercent: 60` / `imageGCLowThresholdPercent: 50` in the Flatcar kubeadm `init-config.yaml` KubeletConfiguration.

## Why
The Rook Ceph mon shares each node's root/ephemeral fs with the containerd image store. kubelet's default imageGC high=85 lets the image cache grow until Ceph's `mon_data_avail_warn` (30% avail / 70% used) flags `MON_DISK_LOW` on the busiest node (k8s-1, 70 pods sat at 30% avail with a 37Gi image cache). Trimming earlier keeps unused images from ever crossing Ceph's warn line.

## Live state
Already rolled to the running cluster out-of-band (kubeadm clusters don't reconcile this from git): patched `kube-system/kubelet-config` ConfigMap, then `kubeadm upgrade node phase kubelet-config` + kubelet restart across k8s-0 → k8s-2 → k8s-1 with etcd/mon-quorum gates. Result: k8s-1 image GC reclaimed ~13Gi, avail 30% → 59%, **Ceph HEALTH_OK**. This PR makes freshly-bootstrapped nodes inherit the same setting.