### PR TITLE
fix(homeops-cli): make krew kubectl plugins discoverable (browse-pvc, node-shell)

### DIFF
--- a/cmd/homeops-cli/cmd/kubernetes/kubernetes.go
+++ b/cmd/homeops-cli/cmd/kubernetes/kubernetes.go
@@ -55,7 +55,8 @@ var (
 	installKubectlPluginFn = func(plugin string) error {
 		return common.Command("kubectl", "krew", "install", plugin).Run()
 	}
-	commandOutputFn = func(name string, args ...string) ([]byte, error) {
+	ensureKrewPathFn = ensureKrewPath
+	commandOutputFn  = func(name string, args ...string) ([]byte, error) {
 		return runKubernetesCommandOutput(name, args...)
 	}
 	commandRunFn = func(name string, args ...string) error {
@@ -348,15 +349,58 @@ func selectKubectlResource(namespace, resourceType, prompt string) (string, erro
 	return selected, nil
 }
 
+// ensureKrewPath makes krew-installed kubectl plugins discoverable by
+// prepending ${KREW_ROOT:-$HOME/.krew}/bin to PATH for this process and every
+// kubectl child it spawns. Krew installs plugins there, but it is not on PATH
+// unless the user added it to their shell rc — without it, kubectl cannot find
+// any krew plugin (browse-pvc, node-shell, ...). Idempotent; a no-op when the
+// dir is already on PATH or the home directory cannot be resolved.
+func ensureKrewPath() {
+	root := os.Getenv("KREW_ROOT")
+	if root == "" {
+		home, err := os.UserHomeDir()
+		if err != nil || home == "" {
+			return
+		}
+		root = filepath.Join(home, ".krew")
+	}
+	binDir := filepath.Join(root, "bin")
+
+	path := os.Getenv("PATH")
+	for _, p := range filepath.SplitList(path) {
+		if p == binDir {
+			return // already present
+		}
+	}
+	if path == "" {
+		_ = os.Setenv("PATH", binDir)
+		return
+	}
+	_ = os.Setenv("PATH", binDir+string(os.PathListSeparator)+path)
+}
+
+// ensureKubectlPlugin makes a krew-managed kubectl plugin available. It first
+// ensures the krew bin dir is on PATH (so an already-installed plugin is found
+// and so kubectl can later discover it), installs the plugin if missing, and
+// then verifies the binary really resolved — turning the previously-silent
+// "unknown command" failure into an actionable error. binaryName must be the
+// on-disk name krew produces (dashes become underscores, e.g.
+// kubectl-browse_pvc); pluginName is the krew index name (e.g. browse-pvc).
 func ensureKubectlPlugin(binaryName, pluginName string) error {
+	ensureKrewPathFn()
 	if _, err := lookPathFn(binaryName); err == nil {
 		return nil
 	}
 
+	common.NewColorLogger().Warn("kubectl %s plugin not installed, installing via krew...", pluginName)
 	if err := installKubectlPluginFn(pluginName); err != nil {
 		return fmt.Errorf("failed to install %s plugin: %w", pluginName, err)
 	}
 
+	ensureKrewPathFn()
+	if _, err := lookPathFn(binaryName); err != nil {
+		return fmt.Errorf("installed the %s plugin but %s is not discoverable on PATH; add ${KREW_ROOT:-$HOME/.krew}/bin to your PATH", pluginName, binaryName)
+	}
 	return nil
 }
 
@@ -481,12 +525,9 @@ func browsePVC(namespace, claim, image string) error {
 		return fmt.Errorf("PVC %s not found in namespace %s", claim, namespace)
 	}
 
-	// Check if kubectl browse-pvc plugin is installed
-	if _, err := lookPathFn("kubectl-browse-pvc"); err != nil {
-		logger.Warn("kubectl browse-pvc plugin not installed, installing via krew...")
-		if err := ensureKubectlPlugin("kubectl-browse-pvc", "browse-pvc"); err != nil {
-			return err
-		}
+	// Ensure the krew browse-pvc plugin is installed and discoverable on PATH.
+	if err := ensureKubectlPlugin("kubectl-browse_pvc", "browse-pvc"); err != nil {
+		return err
 	}
 
 	logger.Info("Mounting PVC %s/%s to temporary container", namespace, claim)
@@ -555,12 +596,9 @@ func nodeShell(node string) error {
 		return fmt.Errorf("node %s not found", node)
 	}
 
-	// Check if kubectl node-shell plugin is installed
-	if _, err := lookPathFn("kubectl-node-shell"); err != nil {
-		logger.Warn("kubectl node-shell plugin not installed, installing via krew...")
-		if err := ensureKubectlPlugin("kubectl-node-shell", "node-shell"); err != nil {
-			return err
-		}
+	// Ensure the krew node-shell plugin is installed and discoverable on PATH.
+	if err := ensureKubectlPlugin("kubectl-node_shell", "node-shell"); err != nil {
+		return err
 	}
 
 	logger.Info("Opening shell to node %s", node)

--- a/cmd/homeops-cli/cmd/kubernetes/kubernetes_flow_test.go
+++ b/cmd/homeops-cli/cmd/kubernetes/kubernetes_flow_test.go
@@ -482,6 +482,7 @@ func TestBrowsePVC(t *testing.T) {
 	oldInstallPlugin := installKubectlPluginFn
 	oldKubectlInteractive := kubectlRunInteractiveFn
 	oldSleep := sleepFn
+	oldKrew := ensureKrewPathFn
 	t.Cleanup(func() {
 		kubectlOutputFn = oldKubectlOutput
 		chooseOptionFn = oldChoose
@@ -490,8 +491,10 @@ func TestBrowsePVC(t *testing.T) {
 		installKubectlPluginFn = oldInstallPlugin
 		kubectlRunInteractiveFn = oldKubectlInteractive
 		sleepFn = oldSleep
+		ensureKrewPathFn = oldKrew
 	})
 
+	ensureKrewPathFn = func() {}
 	kubectlOutputFn = func(args ...string) ([]byte, error) {
 		switch strings.Join(args, " ") {
 		case "get pvc -n media -o jsonpath={.items[*].metadata.name}":
@@ -513,14 +516,15 @@ func TestBrowsePVC(t *testing.T) {
 		return nil
 	}
 
+	var installedPlugin string
+	// The browse_pvc binary is missing until the krew install runs.
 	lookPathFn = func(file string) (string, error) {
-		if file == "kubectl-browse-pvc" {
+		if file == "kubectl-browse_pvc" && installedPlugin == "" {
 			return "", errors.New("missing")
 		}
 		return "/usr/bin/" + file, nil
 	}
 
-	var installedPlugin string
 	installKubectlPluginFn = func(plugin string) error {
 		installedPlugin = plugin
 		return nil
@@ -603,6 +607,7 @@ func TestNodeShell(t *testing.T) {
 	oldLookPath := lookPathFn
 	oldInstallPlugin := installKubectlPluginFn
 	oldKubectlInteractive := kubectlRunInteractiveFn
+	oldKrew := ensureKrewPathFn
 	t.Cleanup(func() {
 		kubectlOutputFn = oldKubectlOutput
 		chooseOptionFn = oldChoose
@@ -610,8 +615,10 @@ func TestNodeShell(t *testing.T) {
 		lookPathFn = oldLookPath
 		installKubectlPluginFn = oldInstallPlugin
 		kubectlRunInteractiveFn = oldKubectlInteractive
+		ensureKrewPathFn = oldKrew
 	})
 
+	ensureKrewPathFn = func() {}
 	kubectlOutputFn = func(args ...string) ([]byte, error) {
 		assert.Equal(t, []string{"get", "nodes", "-o", "jsonpath={.items[*].metadata.name}"}, args)
 		return []byte("cp01 wk01"), nil
@@ -627,8 +634,8 @@ func TestNodeShell(t *testing.T) {
 		return nil
 	}
 	lookPathFn = func(file string) (string, error) {
-		assert.Equal(t, "kubectl-node-shell", file)
-		return "/usr/bin/kubectl-node-shell", nil
+		assert.Equal(t, "kubectl-node_shell", file)
+		return "/usr/bin/kubectl-node_shell", nil
 	}
 	installKubectlPluginFn = func(plugin string) error {
 		t.Fatalf("unexpected plugin install: %s", plugin)

--- a/cmd/homeops-cli/cmd/kubernetes/kubernetes_interactive_test.go
+++ b/cmd/homeops-cli/cmd/kubernetes/kubernetes_interactive_test.go
@@ -57,23 +57,31 @@ func TestSelectKubectlResourceCancellation(t *testing.T) {
 func TestEnsureKubectlPlugin(t *testing.T) {
 	oldLookPath := lookPathFn
 	oldInstall := installKubectlPluginFn
+	oldKrew := ensureKrewPathFn
 	t.Cleanup(func() {
 		lookPathFn = oldLookPath
 		installKubectlPluginFn = oldInstall
+		ensureKrewPathFn = oldKrew
 	})
 
+	ensureKrewPathFn = func() {}
+	installed := false
 	called := 0
 	lookPathFn = func(file string) (string, error) {
-		assert.Equal(t, "kubectl-browse-pvc", file)
+		assert.Equal(t, "kubectl-browse_pvc", file)
+		if installed {
+			return "/path/" + file, nil
+		}
 		return "", fmt.Errorf("missing")
 	}
 	installKubectlPluginFn = func(plugin string) error {
 		called++
 		assert.Equal(t, "browse-pvc", plugin)
+		installed = true
 		return nil
 	}
 
-	require.NoError(t, ensureKubectlPlugin("kubectl-browse-pvc", "browse-pvc"))
+	require.NoError(t, ensureKubectlPlugin("kubectl-browse_pvc", "browse-pvc"))
 	assert.Equal(t, 1, called)
 }
 
@@ -131,14 +139,17 @@ func TestBrowsePVCCleansAllStalePods(t *testing.T) {
 	oldOutput := kubectlOutputFn
 	oldInteractive := kubectlRunInteractiveFn
 	oldSleep := sleepFn
+	oldKrew := ensureKrewPathFn
 	t.Cleanup(func() {
 		lookPathFn = oldLookPath
 		kubectlRunFn = oldRun
 		kubectlOutputFn = oldOutput
 		kubectlRunInteractiveFn = oldInteractive
 		sleepFn = oldSleep
+		ensureKrewPathFn = oldKrew
 	})
 
+	ensureKrewPathFn = func() {}
 	var deleted []string
 	lookPathFn = func(file string) (string, error) { return "/usr/bin/" + file, nil }
 	kubectlRunFn = func(args ...string) error {
@@ -176,20 +187,29 @@ func TestNodeShellInstallsPluginAndRunsInteractive(t *testing.T) {
 	oldInstall := installKubectlPluginFn
 	oldRun := kubectlRunFn
 	oldInteractive := kubectlRunInteractiveFn
+	oldKrew := ensureKrewPathFn
 	t.Cleanup(func() {
 		lookPathFn = oldLookPath
 		installKubectlPluginFn = oldInstall
 		kubectlRunFn = oldRun
 		kubectlRunInteractiveFn = oldInteractive
+		ensureKrewPathFn = oldKrew
 	})
 
+	ensureKrewPathFn = func() {}
 	installs := 0
+	installed := false
 	lookPathFn = func(file string) (string, error) {
+		assert.Equal(t, "kubectl-node_shell", file)
+		if installed {
+			return "/path/" + file, nil
+		}
 		return "", fmt.Errorf("missing")
 	}
 	installKubectlPluginFn = func(plugin string) error {
 		installs++
 		assert.Equal(t, "node-shell", plugin)
+		installed = true
 		return nil
 	}
 	kubectlRunFn = func(args ...string) error {


### PR DESCRIPTION
## Why

After #1258, running `homeops-cli k8s browse-pvc` (and `node-shell`) fails even though the krew plugin is installed:

```
WARN kubectl browse-pvc plugin not installed, installing via krew...
INFO Mounting PVC automation/n8n to temporary container
error: unknown command "browse-pvc" for "kubectl"
```

Two bugs:
1. **`~/.krew/bin` is not on `PATH`.** krew installs plugins into `${KREW_ROOT:-$HOME/.krew}/bin`, which is only on `PATH` if the user added it to their shell rc. The CLI shells out to `kubectl` without it, so kubectl can't discover *any* krew plugin.
2. **Wrong binary name in the install check.** krew produces `kubectl-browse_pvc` / `kubectl-node_shell` (underscores), but the code looked up `kubectl-browse-pvc` / `kubectl-node-shell` (dashes), so the "not installed" check always tripped and the spurious install/warn ran every time.

## What

- Prepend the krew bin dir to `PATH` for the CLI process (and the `kubectl` children it spawns) before using a krew plugin (`ensureKrewPath`).
- Look up the binary by the name krew actually produces (`kubectl-browse_pvc`, `kubectl-node_shell`).
- After install, verify the binary resolves and return an actionable error (`add ${KREW_ROOT:-$HOME/.krew}/bin to your PATH`) instead of letting `kubectl` fail later with a cryptic unknown-command error.

## Verification

`make check` passes (gofmt, `go vet`, golangci-lint 0 issues, `go test -race -short` across 33 packages). Confirmed `kubectl browse-pvc` resolves to the plugin once `~/.krew/bin` is on `PATH` (the exact behavior `ensureKrewPath` now provides).

https://claude.ai/code/session_0116UjmqQYoMYHYo3UbWMBk8
