### PR TITLE
feat(observability): SNMP fabric + GeoIP/feed health monitoring (edge audit Part A)

### DIFF
--- a/kubernetes/apps/observability/victoria-metrics/app/kustomization.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/kustomization.yaml
@@ -9,10 +9,12 @@ resources:
   - ./externalsecret.yaml
   # OIDC and HTTPRoutes moved to vmauth
   - ./vmstaticscrape.yaml
+  - ./snmp-exporter-scrape.yaml
   - ./vmservicescrape-stack.yaml
   - ./vmrule-stack.yaml
   - ./vmrule-infrastructure.yaml
   - ./vmrule-network-infra.yaml
+  - ./vmrule-snmp-geoip.yaml
   - ./vmrule-recording.yaml
   - ./grafanadashboards.yaml
   - ./dnsdist-dashboard.yaml

--- a/kubernetes/apps/observability/victoria-metrics/app/snmp-exporter-scrape.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/snmp-exporter-scrape.yaml
@@ -1,0 +1,128 @@
+---
+# SNMP scrape via nflo0-hosted snmp_exporter (netflow.${SECRET_DOMAIN}:9116).
+# nflo0 (192.168.120.9) is in every device's SNMP source-ACL and reuses the
+# existing ntopng v3 creds (auth module "ntopng_v3"), so no device-side SNMP
+# config change was needed. Multi-module concat is used per device class.
+#
+# Cisco devices (SC01, gateway1): IF-MIB + Cisco CPU/mem + BGP4-MIB.
+# yaml-language-server: $schema=https://kubernetes-schema.pages.dev/operator.victoriametrics.com/vmstaticscrape_v1beta1.json
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMStaticScrape
+metadata:
+  name: snmp-cisco
+spec:
+  jobName: snmp-cisco
+  targetEndpoints:
+    - targets:
+        - "10.255.255.253" # SC01 (BGP4-MIB shows the 3-way ECMP peers + gateway1)
+        - "10.255.255.252" # gateway1 (ISR)
+      path: /snmp
+      interval: 60s
+      scrapeTimeout: 30s
+      params:
+        auth:
+          - ntopng_v3
+        module:
+          - if_mib
+          - cisco_health
+          - bgp
+      labels:
+        job: snmp
+      relabelConfigs:
+        - sourceLabels: ["__address__"]
+          targetLabel: __param_target
+        - sourceLabels: ["__param_target"]
+          targetLabel: instance
+        - targetLabel: __address__
+          replacement: "netflow.${SECRET_DOMAIN}:9116"
+---
+# VyOS cell-gateways: IF-MIB only (FRR AgentX BGP4-MIB not enabled on VyOS).
+# yaml-language-server: $schema=https://kubernetes-schema.pages.dev/operator.victoriametrics.com/vmstaticscrape_v1beta1.json
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMStaticScrape
+metadata:
+  name: snmp-vyos-cellgw
+spec:
+  jobName: snmp-vyos
+  targetEndpoints:
+    - targets:
+        - "10.255.255.251" # cell-gateway0
+        - "10.255.255.250" # cell-gateway1
+      path: /snmp
+      interval: 60s
+      scrapeTimeout: 30s
+      params:
+        auth:
+          - ntopng_v3
+        module:
+          - if_mib
+      labels:
+        job: snmp
+      relabelConfigs:
+        - sourceLabels: ["__address__"]
+          targetLabel: __param_target
+        - sourceLabels: ["__param_target"]
+          targetLabel: instance
+        - targetLabel: __address__
+          replacement: "netflow.${SECRET_DOMAIN}:9116"
+---
+# gateway0 (primary edge): IF-MIB + GeoIP/threat-feed health via NET-SNMP-EXTEND-MIB
+# (script-extensions backed by a root task-scheduler materializer; snmpd is non-root).
+# yaml-language-server: $schema=https://kubernetes-schema.pages.dev/operator.victoriametrics.com/vmstaticscrape_v1beta1.json
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMStaticScrape
+metadata:
+  name: snmp-gateway0
+spec:
+  jobName: snmp-geoip
+  targetEndpoints:
+    - targets:
+        - "10.255.255.254" # gateway0
+      path: /snmp
+      interval: 60s
+      scrapeTimeout: 30s
+      params:
+        auth:
+          - ntopng_v3
+        module:
+          - if_mib
+          - net_snmp_extend
+      labels:
+        job: snmp
+      relabelConfigs:
+        - sourceLabels: ["__address__"]
+          targetLabel: __param_target
+        - sourceLabels: ["__param_target"]
+          targetLabel: instance
+        - targetLabel: __address__
+          replacement: "netflow.${SECRET_DOMAIN}:9116"
+---
+# Active ICMP RTT from the nflo0 vantage (blackbox_exporter :9115) — per-destination
+# WAN latency to correlate with edge throughput (passive ERSPAN cannot derive RTT).
+# yaml-language-server: $schema=https://kubernetes-schema.pages.dev/operator.victoriametrics.com/vmstaticscrape_v1beta1.json
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMStaticScrape
+metadata:
+  name: nflo0-icmp-rtt
+spec:
+  jobName: nflo0-icmp-rtt
+  targetEndpoints:
+    - targets:
+        - "1.1.1.1"
+        - "8.8.8.8"
+        - "9.9.9.9"
+      path: /probe
+      interval: 30s
+      scrapeTimeout: 10s
+      params:
+        module:
+          - icmp
+      labels:
+        job: nflo0-icmp-rtt
+      relabelConfigs:
+        - sourceLabels: ["__address__"]
+          targetLabel: __param_target
+        - sourceLabels: ["__param_target"]
+          targetLabel: instance
+        - targetLabel: __address__
+          replacement: "netflow.${SECRET_DOMAIN}:9115"

--- a/kubernetes/apps/observability/victoria-metrics/app/vmrule-snmp-geoip.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/vmrule-snmp-geoip.yaml
@@ -1,0 +1,184 @@
+---
+# Alerts for the new SNMP fabric telemetry + gateway0 GeoIP/threat-feed health.
+# Metric source: nflo0 snmp_exporter (job="snmp") + NET-SNMP-EXTEND-MIB (job="snmp-geoip").
+# NOTE: the GeoIP* alerts WILL fire on day one — they correctly surface the currently
+# dead GeoIP country-block (sets empty, updater exit!=0, DB ~45d stale). They clear once
+# the gated GeoIP restore (proposal B1) is applied. They are "warning", not paging.
+# yaml-language-server: $schema=https://kubernetes-schema.pages.dev/operator.victoriametrics.com/vmrule_v1beta1.json
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  name: snmp-geoip-alerts
+spec:
+  groups:
+    # ── SNMP target reachability ───────────────────────────────────────────
+    - name: snmp-availability.rules
+      interval: 60s
+      rules:
+        - alert: SNMPTargetDown
+          expr: |-
+            up{job=~"snmp.*"} == 0
+          for: 5m
+          keep_firing_for: 5m
+          annotations:
+            summary: "SNMP target {{ $labels.instance }} not responding"
+            description: |-
+              snmp_exporter (nflo0) is getting no SNMP reply from {{ $labels.instance }}.
+              If this is SC01 (10.255.255.253), it is the known TrustSec return-path gap
+              (cell 18->24 lacks `permit udp src eq snmp`) — see proposal SC01 SNMP fix.
+          labels:
+            severity: warning
+            component: network
+
+    # ── Interface health (IF-MIB) ──────────────────────────────────────────
+    - name: snmp-interfaces.rules
+      interval: 60s
+      rules:
+        - alert: InterfaceErrors
+          expr: |-
+            rate(ifInErrors{job="snmp"}[5m]) + rate(ifOutErrors{job="snmp"}[5m]) > 1
+          for: 10m
+          keep_firing_for: 5m
+          annotations:
+            summary: "Interface errors on {{ $labels.instance }} {{ $labels.ifName }}"
+            description: |-
+              {{ $labels.ifAlias }} ({{ $labels.ifName }}) on {{ $labels.instance }}
+              is accumulating in/out errors (>1/s over 5m).
+          labels:
+            severity: warning
+            component: network
+        - alert: InterfaceDiscards
+          expr: |-
+            rate(ifInDiscards{job="snmp"}[5m]) + rate(ifOutDiscards{job="snmp"}[5m]) > 10
+          for: 15m
+          keep_firing_for: 5m
+          annotations:
+            summary: "Interface discards on {{ $labels.instance }} {{ $labels.ifName }}"
+            description: |-
+              {{ $labels.ifAlias }} ({{ $labels.ifName }}) on {{ $labels.instance }}
+              is discarding packets (>10/s over 5m) — possible congestion or buffer pressure.
+          labels:
+            severity: warning
+            component: network
+        - alert: UplinkDown
+          expr: |-
+            ifOperStatus{job="snmp",ifOperStatus="up",ifAlias=~"(?i).*(transit|uplink|po1|po2|portchannel|nas01|pve).*"} == 0
+          for: 5m
+          keep_firing_for: 5m
+          annotations:
+            summary: "Uplink down: {{ $labels.instance }} {{ $labels.ifName }}"
+            description: |-
+              Transit/uplink {{ $labels.ifAlias }} ({{ $labels.ifName }}) on
+              {{ $labels.instance }} is not in operational-up state.
+          labels:
+            severity: critical
+            component: network
+
+    # ── Cisco control plane (CISCO-PROCESS / MEMORY-POOL MIB) ──────────────
+    - name: snmp-cisco-health.rules
+      interval: 60s
+      rules:
+        - alert: CiscoHighCPU
+          expr: |-
+            cpmCPUTotal5minRev{job="snmp"} > 75
+          for: 10m
+          keep_firing_for: 5m
+          annotations:
+            summary: "High CPU on {{ $labels.instance }}"
+            description: "5-min CPU on {{ $labels.instance }} (index {{ $labels.cpmCPUTotalIndex }}) is {{ $value }}%."
+          labels:
+            severity: warning
+            component: network
+        - alert: CiscoHighMemory
+          expr: |-
+            100 * ciscoMemoryPoolUsed{job="snmp"}
+              / (ciscoMemoryPoolUsed{job="snmp"} + ciscoMemoryPoolFree{job="snmp"}) > 85
+          for: 15m
+          keep_firing_for: 5m
+          annotations:
+            summary: "High memory on {{ $labels.instance }} ({{ $labels.ciscoMemoryPoolName }})"
+            description: "Memory pool {{ $labels.ciscoMemoryPoolName }} on {{ $labels.instance }} is {{ $value | humanize }}% used."
+          labels:
+            severity: warning
+            component: network
+
+    # ── BGP fabric state (BGP4-MIB, Cisco side covers the 3x10G ECMP peers) ─
+    - name: snmp-bgp.rules
+      interval: 60s
+      rules:
+        - alert: BGPPeerNotEstablished
+          expr: |-
+            bgpPeerState{job="snmp",bgpPeerState="established"} == 0
+          for: 5m
+          keep_firing_for: 5m
+          annotations:
+            summary: "BGP peer {{ $labels.bgpPeerRemoteAddr }} down on {{ $labels.instance }}"
+            description: |-
+              BGP session to {{ $labels.bgpPeerRemoteAddr }} (AS {{ $labels.bgpPeerRemoteAs }})
+              on {{ $labels.instance }} is not Established. ECMP/backup path may be degraded.
+          labels:
+            severity: critical
+            component: network
+        - alert: BGPPeerFlapping
+          expr: |-
+            increase(bgpPeerFsmEstablishedTransitions{job="snmp"}[1h]) > 3
+          for: 5m
+          keep_firing_for: 15m
+          annotations:
+            summary: "BGP peer {{ $labels.bgpPeerRemoteAddr }} flapping on {{ $labels.instance }}"
+            description: "{{ $value }} BGP FSM established-transitions in the last hour to {{ $labels.bgpPeerRemoteAddr }}."
+          labels:
+            severity: warning
+            component: network
+
+    # ── gateway0 GeoIP + threat-feed health (NET-SNMP-EXTEND-MIB) ──────────
+    - name: geoip-feed-health.rules
+      interval: 60s
+      rules:
+        - alert: GeoIPBlockEmpty
+          expr: |-
+            nsExtendOutputFull{job="snmp",nsExtendCommand=~"geoip_set_elements_wan_(local|transit)"} == 0
+          for: 15m
+          keep_firing_for: 10m
+          annotations:
+            summary: "GeoIP country-block set empty ({{ $labels.nsExtendCommand }})"
+            description: |-
+              gateway0 GeoIP nft set {{ $labels.nsExtendCommand }} has 0 elements — the
+              cn/ru/kp/ir/by country-block is providing NO protection. Apply proposal B1
+              (configure firewall global-options geoip + run geoip-update.py --init).
+          labels:
+            severity: warning
+            component: security
+        - alert: GeoIPUpdaterFailing
+          expr: |-
+            nsExtendOutputFull{job="snmp",nsExtendCommand="geoip_update_last_exit"} != 0
+          for: 1h
+          keep_firing_for: 30m
+          annotations:
+            summary: "gateway0 GeoIP updater failing"
+            description: "geoip-update.py last run returned non-zero — GeoIP DB not refreshing."
+          labels:
+            severity: warning
+            component: security
+        - alert: GeoIPDatabaseStale
+          expr: |-
+            nsExtendOutputFull{job="snmp",nsExtendCommand="geoip_conf_age_seconds"} > 1209600
+          for: 1h
+          keep_firing_for: 30m
+          annotations:
+            summary: "gateway0 GeoIP database stale"
+            description: "nftables-geoip.conf is {{ $value | humanizeDuration }} old (>14d) — GeoIP not refreshing."
+          labels:
+            severity: warning
+            component: security
+        - alert: ThreatFeedResolverDown
+          expr: |-
+            nsExtendOutputFull{job="snmp",nsExtendCommand="vyos_domain_resolver_up"} == 0
+          for: 5m
+          keep_firing_for: 5m
+          annotations:
+            summary: "gateway0 vyos-domain-resolver down"
+            description: "The service that refreshes the reputation feeds (firehol/spamhaus/et/feodo/bitwire/hagezi) is not active — feeds will go stale."
+          labels:
+            severity: critical
+            component: security


### PR DESCRIPTION
## What

Part A (safe, additive, **read-only against devices**) of the 2026-06-21 edge perf/security audit. Closes the two real telemetry blind spots: the core L3 switch + backup fabric had **no** interface/CPU/BGP-state metrics, and the dead GeoIP control had **nothing alerting** on it.

### Adds
- **`snmp-exporter-scrape.yaml`** — scrapes the new nflo0-hosted `snmp_exporter` (`netflow:9116`):
  - **Cisco** (SC01, gateway1): IF-MIB + CPU/mem (CISCO-PROCESS/MEMORY-POOL) + **BGP4-MIB** (SC01's view covers the 3×10G ECMP peers + gateway1).
  - **VyOS** (gateway0, cell-gw0/1): IF-MIB. gateway0 also gets **GeoIP/threat-feed health** via NET-SNMP-EXTEND-MIB.
  - **nflo0 active ICMP RTT** (`netflow:9115` blackbox) for load-correlated WAN latency.
- **`vmrule-snmp-geoip.yaml`** — alerts: SNMP target down, interface errors/discards, uplink down, Cisco CPU/mem, BGP peer not-established/flapping, and GeoIP set-empty / updater-failing / DB-stale / resolver-down.

### No device-side config change
nflo0 (192.168.120.9) is already in every device's SNMP source-ACL and reuses the existing `ntopng` v3 creds. gateway0 exposes GeoIP/feed counts via **VyOS-native `script-extensions`** (a root `task-scheduler` materializer writes world-readable counters; non-root `snmpd` `cat`s them) — no new login user, SSH key, or sudoers.

## Expected on merge
The **GeoIP* alerts fire immediately** — by design. They correctly surface the currently-dead country-block (sets empty, updater exit≠0, DB ~45d stale). They clear once the gated **GeoIP restore (proposal B1)** is applied. They are `warning`, not paging.

## Known follow-ups (tracked in the infra proposal, NOT in this PR)
- **SC01 SNMP** returns once a gated SGACL fix lands: cell 18→24 (`RBACL_SWITCH_SVIS_TO_NFLO_EXPORTS`) needs `permit udp src eq snmp` (the SNMP-return ACL is mis-bound to 19→24). Until then `SNMPTargetDown{instance="10.255.255.253"}` fires.
- VyOS FRR AgentX BGP4-MIB is off, so VyOS-side BGP-via-SNMP is empty (Cisco side covers the fabric).

## Validation
`kustomize build` clean (67 docs); all 5 new objects render. Nothing deploys until this merges (Flux watches `main`).

Full audit + gated Part-B plan: `runbooks/proposals/2026-06-21-edge-perf-security-hardening.md` (infra repo).

https://claude.ai/code/session_0116UjmqQYoMYHYo3UbWMBk8