### PR TITLE
fix(observability): scope Po20 polarization alert off the ERSPAN-pinned member

### DIFF
--- a/kubernetes/apps/observability/victoria-metrics/app/vmrule-snmp-geoip.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/vmrule-snmp-geoip.yaml
@@ -64,15 +64,19 @@ spec:
           labels:
             severity: warning
             component: network
-        # 2026-06-26 holistic review: per-member egress drops on a server port-channel
-        # = LACP hash polarization (elephant flows pinned to one 10G member while siblings
-        # idle). Catches the historical Po20 Te1/0/9 tail-drops. ifOutDiscards is per-member;
-        # more specific than InterfaceDiscards (>10/s broad) — flags lower-rate single-member
-        # drops on the nas01/virt server bundles (Te1/0/9-16). Source-side fix is flow-tuple
-        # spread (nas01 bond xmit_hash_policy, more NVMe-oF sessions), NOT SC01's global hash.
+        # 2026-06-26: per-member egress drops on a server port-channel = LACP hash
+        # polarization (one 10G member tail-dropping while siblings stay clean). Scoped to
+        # the spreadable server-bundle members Te1/0/10-16 ONLY. Te1/0/9 is DELIBERATELY
+        # EXCLUDED: investigation (2026-06-26) showed its drops are the nflo0 ERSPAN GRE feed
+        # (Vlan998 10.255.255.37 -> .38) — a single portless IP-pair flow that NO LACP hash
+        # can spread, so it permanently pins to Te1/0/9 and tail-drops in the default best-
+        # effort queue under microbursts. Those are mirror COPIES (~0.76% of the feed lost,
+        # originals forward fine) = zero production impact, so alerting on them is noise.
+        # Real storage/VM traffic spreads across Te1/0/10-16, so a drop THERE means actual
+        # loss worth investigating. Source-side flow spread is the fix, NOT SC01's global hash.
         - alert: SC01PortChannelMemberPolarized
           expr: |-
-            increase(ifOutDiscards{job=~"snmp.*",instance="10.255.255.253",ifName=~"Te1/0/(9|1[0-6])"}[15m]) > 1000
+            increase(ifOutDiscards{job=~"snmp.*",instance="10.255.255.253",ifName=~"Te1/0/1[0-6]"}[15m]) > 1000
           for: 5m
           keep_firing_for: 15m
           annotations:


### PR DESCRIPTION
## Why
`SC01PortChannelMemberPolarized` fired on **Te1/0/9** (40.97k drops/15m). Live investigation: Te1/0/9 carries the **nflo0 ERSPAN GRE feed** (`Vlan998 10.255.255.37 → .38`) — a single portless IP-pair flow no LACP hash can spread, so it permanently pins there and tail-drops mirror **copies** in the default best-effort queue under microbursts. ~0.76% of the feed lost; **originals forward fine = zero production impact**. Po20 = pve; its other 3 members (and Po10/nas01) drop 0.

## Change
Exclude Te1/0/9 → rule now scoped to `Te1/0/10-16`. Real storage/VM traffic spreads across those members, so a drop there is genuinely actionable. Verified live: selector matches 7 members, excludes Te1/0/9. VMRule parses clean.

https://claude.ai/code/session_01PJygzRnKt6PVJwmQzy2YSG