### PR TITLE
feat(storage): add scale-csi (TrueNAS NVMe-oF/iSCSI/NFS) CSI driver

### DIFF
--- a/kubernetes/apps/scale-csi/kustomization.yaml
+++ b/kubernetes/apps/scale-csi/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: scale-csi
+components:
+  - ../../components/alerts
+  - ../../components/cluster-secret
+
+resources:
+  - ./namespace.yaml
+  - ./scale-csi/ks.yaml

--- a/kubernetes/apps/scale-csi/namespace.yaml
+++ b/kubernetes/apps/scale-csi/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: scale-csi
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/scale-csi/scale-csi/app/externalsecret.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schema.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: scale-csi
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: scale-csi-secret
+    template:
+      data:
+        api-key: "{{ .TRUENAS_APIKEY }}"
+  dataFrom:
+    - extract:
+        key: truenas-csi

--- a/kubernetes/apps/scale-csi/scale-csi/app/helmrelease.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/helmrelease.yaml
@@ -10,6 +10,11 @@ spec:
     name: scale-csi
   interval: 1h
   values:
+    image:
+      # Chart appVersion renders the tag without the leading "v"; the published
+      # image tag is v-prefixed, so pin it explicitly (kept in sync with the
+      # OCIRepository chart tag by Renovate).
+      tag: v1.2.17
     truenas:
       host: "192.168.120.10"
       port: 443

--- a/kubernetes/apps/scale-csi/scale-csi/app/helmrelease.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/helmrelease.yaml
@@ -1,0 +1,67 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schema.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: scale-csi
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: scale-csi
+  interval: 1h
+  values:
+    truenas:
+      host: "192.168.120.10"
+      port: 443
+      secure: true
+      skipTLSVerify: true
+      existingSecret: scale-csi-secret
+    zfs:
+      parentDataset: flashstor/scale-csi
+      enforceQuota: true
+    nfs:
+      enabled: true
+      server: "192.168.120.10"
+      shareAllowedNetworks:
+        - 192.168.120.0/22
+    iscsi:
+      enabled: true
+      portal: "192.168.120.10:3260"
+    nvmeof:
+      enabled: true
+      transport: tcp
+      address: "192.168.120.10"
+      port: 4420
+      # Secure-by-default: only these Kubernetes node NQNs may connect
+      # (nvme show-hostnqn per node; machine-id-derived, stable on Flatcar).
+      subsystemAllowAnyHost: false
+      subsystemHosts:
+        - nqn.2014-08.org.nvmexpress:uuid:cce109e7-813a-4b2b-9314-c35b7064e3dd
+        - nqn.2014-08.org.nvmexpress:uuid:0c2178cc-5aa6-45f3-bafe-718fe518fa62
+        - nqn.2014-08.org.nvmexpress:uuid:2121dcbe-603f-46ec-b21a-b3dbad9d5f04
+    storageClasses:
+      - name: scale-nvmeof
+        protocol: nvmeof
+        isDefault: false
+        reclaimPolicy: Delete
+        allowVolumeExpansion: true
+        volumeBindingMode: Immediate
+      - name: scale-iscsi
+        protocol: iscsi
+        isDefault: false
+        reclaimPolicy: Delete
+        allowVolumeExpansion: true
+        volumeBindingMode: Immediate
+      - name: scale-nfs
+        protocol: nfs
+        isDefault: false
+        reclaimPolicy: Delete
+        allowVolumeExpansion: true
+        volumeBindingMode: Immediate
+        mountOptions:
+          - nfsvers=4
+          - noatime
+    snapshotClass:
+      create: true
+      name: scale-snapshot
+      deletionPolicy: Delete

--- a/kubernetes/apps/scale-csi/scale-csi/app/kustomization.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/scale-csi/scale-csi/app/ocirepository.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schema.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: scale-csi
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.2.17
+  url: oci://ghcr.io/gizmotickler/charts/scale-csi

--- a/kubernetes/apps/scale-csi/scale-csi/ks.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/ks.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schema.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: scale-csi
+spec:
+  dependsOn:
+    - name: external-secrets
+      namespace: external-secrets
+    - name: snapshot-controller
+      namespace: kube-system
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: scale-csi
+      namespace: scale-csi
+  interval: 1h
+  path: ./kubernetes/apps/scale-csi/scale-csi/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: scale-csi
+  wait: true


### PR DESCRIPTION
## Phase 0 — foundation for migrating app storage off Rook Ceph → scale-csi

Deploys **scale-csi v1.2.17** as a first-class Flux app (`kubernetes/apps/scale-csi/`), mirroring the rook-ceph/openebs pattern. **Non-destructive**: adds a new driver alongside Rook; no existing PVCs or Rook resources are touched.

### What's included
- `OCIRepository` → `oci://ghcr.io/gizmotickler/charts/scale-csi:1.2.17`
- `ExternalSecret` `truenas-csi` → `scale-csi-secret` (TrueNAS API key via 1Password `onepassword` store)
- `HelmRelease` — driver `csi.scale.io`, backend nas01 `flashstor/scale-csi` (no refquota)
- StorageClasses **scale-nvmeof** (primary), scale-iscsi, scale-nfs + VolumeSnapshotClass **scale-snapshot**
- NVMe-oF **secure-by-default**: `subsystemAllowAnyHost=false` + 3 node-NQN allowlist

### Validated locally
- `kubectl kustomize` builds clean (app + namespace w/ components)
- `helm template` against chart 1.2.17 renders 16 resources; CSIDriver `csi.scale.io`, SCs + snapshotclass correct, allowlist + secret refs wired
- scale-csi v1.2.17 already live-validated (all protocols, full block surface, snapshots/clone/expand, 0 leaks) in the scale-csi-test namespace + fio benchmarked vs Rook

### Deploy note
The ephemeral `scale-csi-test` release (same driver name `csi.scale.io`) must be uninstalled before this reconciles, to avoid a node-plugin registration collision.

Part of the staged Rook→scale-csi migration (Phase 0). Later phases migrate app data via VolSync restore-on-create and CNPG recovery, gated per phase.