### PR TITLE
migrate(pocket-id): storage ceph-block -> scale-nvmeof (canary)

### DIFF
--- a/kubernetes/apps/auth/pocket-id/ks.yaml
+++ b/kubernetes/apps/auth/pocket-id/ks.yaml
@@ -18,6 +18,8 @@ spec:
     substitute:
       APP: pocket-id
       VOLSYNC_CAPACITY: 1Gi
+      VOLSYNC_STORAGECLASS: scale-nvmeof
+      VOLSYNC_SNAPSHOTCLASS: scale-snapshot
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
First canary of the Rook->scale-csi migration. Points pocket-id's VolSync PVC + ReplicationDestination at scale-nvmeof/scale-snapshot. Fresh backup verified (lastSyncTime 16:40:02Z, Successful). Cutover: scale down -> delete ceph PVC+RD -> Flux recreates on scale-nvmeof -> VolSync restores from Kopia. Data safety net = Kopia backup on nas01 NFS.