### PR TITLE
feat(scale-csi): v1.2.19 + detachedVolumesFromSnapshots

### DIFF
--- a/kubernetes/apps/scale-csi/scale-csi/app/helmrelease.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/helmrelease.yaml
@@ -10,11 +10,6 @@ spec:
     name: scale-csi
   interval: 1h
   values:
-    image:
-      # Chart appVersion renders the tag without the leading "v"; the published
-      # image tag is v-prefixed, so pin it explicitly (kept in sync with the
-      # OCIRepository chart tag by Renovate).
-      tag: v1.2.17
     truenas:
       host: "192.168.120.10"
       port: 443
@@ -24,6 +19,10 @@ spec:
     zfs:
       parentDataset: flashstor/scale-csi
       enforceQuota: true
+      # VolSync restores create the app PVC from a VolumeSnapshot; make it a full
+      # independent copy (zfs send|recv) instead of a dependent clone so the
+      # restore intermediate is deletable and no orphan Released PV is left behind.
+      detachedVolumesFromSnapshots: true
     nfs:
       enabled: true
       server: "192.168.120.10"

--- a/kubernetes/apps/scale-csi/scale-csi/app/ocirepository.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.2.17
+    tag: 1.2.19
   url: oci://ghcr.io/gizmotickler/charts/scale-csi


### PR DESCRIPTION
Bumps scale-csi to **v1.2.19** and enables `zfs.detachedVolumesFromSnapshots`.

- **Chart fix (v1.2.19):** image tag now defaults to `v<appVersion>` matching the published image, so the `image.tag` pin is removed — the OCIRepository chart tag is the single Renovate-managed version.
- **detachedVolumesFromSnapshots: true** — VolSync restores now create an independent copy (`replication.run_onetime` LOCAL = zfs send|recv) instead of a ZFS clone, so the restore intermediate is deletable and no orphan Released PV is left per migrated app. Opus-reviewed (2 findings fixed), full -race gauntlet green.

Unblocks clean Rook->scale-csi app migrations (Phase 1 batch).