### PR TITLE
feat(scale-csi): bump to v1.2.20 (detached-copy fix)

### DIFF
--- a/kubernetes/apps/scale-csi/scale-csi/app/ocirepository.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.2.19
+    tag: 1.2.20
   url: oci://ghcr.io/gizmotickler/charts/scale-csi


### PR DESCRIPTION
Bumps scale-csi chart/image to v1.2.20 (OCIRepository tag only — image derives from the chart's appVersion after the v1.2.19 helper fix). v1.2.20 fixes the transferred-snapshot cleanup in the detached-volumes path (was -32602 on a wrong API call, now uses the proven version-detected snapshot delete). Unblocks clean VolSync restores onto scale-csi.