### PR TITLE
feat(scale-csi): bump to v1.2.21 (orphan reconcile/GC)

### DIFF
--- a/kubernetes/apps/scale-csi/scale-csi/app/ocirepository.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.2.20
+    tag: 1.2.21
   url: oci://ghcr.io/gizmotickler/charts/scale-csi


### PR DESCRIPTION
Bumps scale-csi to v1.2.21: driver-side orphan reconcile — default-on READ-ONLY detection loop (gauges scale_csi_orphan_volumes/_snapshots/_spent_restore_snapshots + alert rule), automatic spent-VolSync-restore recognition, and a default-OFF gated delete (CronJob, maxPerRun=5, guarded delete paths, fails closed on zero-live-PV rebuild transients). Adversarially reviewed; full gauntlet green. Keeps flashstor/scale-csi clean through churn and cluster rebuilds.