### PR TITLE
migrate(batch1): freshrss, atuin, actual, recyclarr -> scale-nvmeof

### DIFF
--- a/kubernetes/apps/downloads/recyclarr/ks.yaml
+++ b/kubernetes/apps/downloads/recyclarr/ks.yaml
@@ -16,6 +16,8 @@ spec:
     substitute:
       APP: recyclarr
       VOLSYNC_CAPACITY: 10Gi
+      VOLSYNC_STORAGECLASS: scale-nvmeof
+      VOLSYNC_SNAPSHOTCLASS: scale-snapshot
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/self-hosted/actual/ks.yaml
+++ b/kubernetes/apps/self-hosted/actual/ks.yaml
@@ -16,6 +16,8 @@ spec:
     substitute:
       APP: actual
       VOLSYNC_CAPACITY: 15Gi
+      VOLSYNC_STORAGECLASS: scale-nvmeof
+      VOLSYNC_SNAPSHOTCLASS: scale-snapshot
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/self-hosted/atuin/ks.yaml
+++ b/kubernetes/apps/self-hosted/atuin/ks.yaml
@@ -16,6 +16,8 @@ spec:
     substitute:
       APP: atuin
       VOLSYNC_CAPACITY: 15Gi
+      VOLSYNC_STORAGECLASS: scale-nvmeof
+      VOLSYNC_SNAPSHOTCLASS: scale-snapshot
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/self-hosted/freshrss/ks.yaml
+++ b/kubernetes/apps/self-hosted/freshrss/ks.yaml
@@ -16,6 +16,8 @@ spec:
     substitute:
       APP: freshrss
       VOLSYNC_CAPACITY: 15Gi
+      VOLSYNC_STORAGECLASS: scale-nvmeof
+      VOLSYNC_SNAPSHOTCLASS: scale-snapshot
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
Phase 1 batch 1. Flips VOLSYNC_STORAGECLASS/SNAPSHOTCLASS to scale-nvmeof/scale-snapshot for 4 low-risk apps. Fresh backups verified (batch1-20260720, all Successful). Cutover per app after merge: scale 0 -> delete ceph PVC+RD -> Flux/VolSync restores detached copy -> verify. GC (v1.2.21) monitors for leftovers.