### PR TITLE
feat(scale-csi): enable gated GC delete

### DIFF
--- a/kubernetes/apps/scale-csi/scale-csi/app/helmrelease.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/helmrelease.yaml
@@ -69,3 +69,9 @@ spec:
       create: true
       name: scale-snapshot
       deletionPolicy: Delete
+    reconcile:
+      delete:
+        # Gated GC: nightly CronJob releases spent VolSync-restore snapshots and
+        # deletes true orphans (>24h old, capped 5/run, guarded delete paths,
+        # fails closed during cluster rebuilds). Detection/alerting is always on.
+        enabled: true


### PR DESCRIPTION
Enables reconcile.delete (nightly 4am CronJob, maxPerRun=5, minOrphanAge 24h, guarded delete paths, fails closed on zero-live-PV rebuild transients). Cleans the 4 spent VolSync-restore snapshots from batch 1 automatically once they age past 24h, and keeps flashstor/scale-csi clean going forward. Detection/alerting already always-on.