### PR TITLE
migrate(batch2): remaining 11 apps + caches -> scale-nvmeof

### DIFF
--- a/kubernetes/apps/automation/n8n/ks.yaml
+++ b/kubernetes/apps/automation/n8n/ks.yaml
@@ -16,6 +16,8 @@ spec:
     substitute:
       APP: n8n
       VOLSYNC_CAPACITY: 15Gi
+      VOLSYNC_STORAGECLASS: scale-nvmeof
+      VOLSYNC_SNAPSHOTCLASS: scale-snapshot
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/downloads/autobrr/ks.yaml
+++ b/kubernetes/apps/downloads/autobrr/ks.yaml
@@ -17,6 +17,8 @@ spec:
     substitute:
       APP: autobrr
       VOLSYNC_CAPACITY: 50Gi
+      VOLSYNC_STORAGECLASS: scale-nvmeof
+      VOLSYNC_SNAPSHOTCLASS: scale-snapshot
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/downloads/bazarr/ks.yaml
+++ b/kubernetes/apps/downloads/bazarr/ks.yaml
@@ -19,6 +19,8 @@ spec:
     substitute:
       APP: bazarr
       VOLSYNC_CAPACITY: 10Gi
+      VOLSYNC_STORAGECLASS: scale-nvmeof
+      VOLSYNC_SNAPSHOTCLASS: scale-snapshot
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/downloads/nzbget/ks.yaml
+++ b/kubernetes/apps/downloads/nzbget/ks.yaml
@@ -17,6 +17,8 @@ spec:
     substitute:
       APP: nzbget
       VOLSYNC_CAPACITY: 15Gi
+      VOLSYNC_STORAGECLASS: scale-nvmeof
+      VOLSYNC_SNAPSHOTCLASS: scale-snapshot
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/downloads/pinchflat/ks.yaml
+++ b/kubernetes/apps/downloads/pinchflat/ks.yaml
@@ -19,6 +19,8 @@ spec:
     substitute:
       APP: pinchflat
       VOLSYNC_CAPACITY: 10Gi
+      VOLSYNC_STORAGECLASS: scale-nvmeof
+      VOLSYNC_SNAPSHOTCLASS: scale-snapshot
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/downloads/prowlarr/ks.yaml
+++ b/kubernetes/apps/downloads/prowlarr/ks.yaml
@@ -19,6 +19,8 @@ spec:
     substitute:
       APP: prowlarr
       VOLSYNC_CAPACITY: 10Gi
+      VOLSYNC_STORAGECLASS: scale-nvmeof
+      VOLSYNC_SNAPSHOTCLASS: scale-snapshot
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/downloads/qbittorrent/ks.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/ks.yaml
@@ -19,6 +19,8 @@ spec:
     substitute:
       APP: qbittorrent
       VOLSYNC_CAPACITY: 15Gi
+      VOLSYNC_STORAGECLASS: scale-nvmeof
+      VOLSYNC_SNAPSHOTCLASS: scale-snapshot
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/downloads/qui/ks.yaml
+++ b/kubernetes/apps/downloads/qui/ks.yaml
@@ -19,6 +19,8 @@ spec:
     substitute:
       APP: qui
       VOLSYNC_CAPACITY: 15Gi
+      VOLSYNC_STORAGECLASS: scale-nvmeof
+      VOLSYNC_SNAPSHOTCLASS: scale-snapshot
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/downloads/radarr/app/pvc.yaml
+++ b/kubernetes/apps/downloads/radarr/app/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   resources:
     requests:
       storage: 10Gi
-  storageClassName: ceph-block
+  storageClassName: scale-nvmeof

--- a/kubernetes/apps/downloads/radarr/ks.yaml
+++ b/kubernetes/apps/downloads/radarr/ks.yaml
@@ -19,6 +19,8 @@ spec:
     substitute:
       APP: radarr
       VOLSYNC_CAPACITY: 15Gi
+      VOLSYNC_STORAGECLASS: scale-nvmeof
+      VOLSYNC_SNAPSHOTCLASS: scale-snapshot
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/downloads/sonarr/app/pvc.yaml
+++ b/kubernetes/apps/downloads/sonarr/app/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   resources:
     requests:
       storage: 10Gi
-  storageClassName: ceph-block
+  storageClassName: scale-nvmeof

--- a/kubernetes/apps/downloads/sonarr/ks.yaml
+++ b/kubernetes/apps/downloads/sonarr/ks.yaml
@@ -19,6 +19,8 @@ spec:
     substitute:
       APP: sonarr
       VOLSYNC_CAPACITY: 15Gi
+      VOLSYNC_STORAGECLASS: scale-nvmeof
+      VOLSYNC_SNAPSHOTCLASS: scale-snapshot
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/seerr/app/pvc.yaml
+++ b/kubernetes/apps/media/seerr/app/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   resources:
     requests:
       storage: 15Gi
-  storageClassName: ceph-block
+  storageClassName: scale-nvmeof

--- a/kubernetes/apps/media/seerr/ks.yaml
+++ b/kubernetes/apps/media/seerr/ks.yaml
@@ -19,6 +19,8 @@ spec:
     substitute:
       APP: seerr
       VOLSYNC_CAPACITY: 50Gi
+      VOLSYNC_STORAGECLASS: scale-nvmeof
+      VOLSYNC_SNAPSHOTCLASS: scale-snapshot
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
Phase 1 completion. Flips VOLSYNC classes for the 11 remaining backed-up apps + the 3 cache PVCs (recreate empty). Fresh backups all Successful. Cutover per app after merge with the batch-1 lessons applied (ks-CR verification, finished-job clearing). GC (v1.2.21, delete enabled) auto-cleans restore leftovers after age-gate.