### PR TITLE
migrate(phase2): observability storage -> scale-nvmeof (fresh)

### DIFF
--- a/kubernetes/apps/observability/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/app/helmrelease.yaml
@@ -71,7 +71,7 @@ spec:
         statefulset:
           volumeClaimTemplates:
             - name: config
-              storageClass: ceph-block
+              storageClass: scale-nvmeof
               accessMode: ReadWriteOnce
               size: 15Gi
     defaultPodOptions:

--- a/kubernetes/apps/observability/grafana/instance/grafana.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafana.yaml
@@ -116,5 +116,5 @@ spec:
       resources:
         requests:
           storage: 20Gi
-      storageClassName: ceph-block
+      storageClassName: scale-nvmeof
   disableDefaultSecurityContext: All

--- a/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
@@ -22,7 +22,7 @@ spec:
     server:
       persistentVolume:
         enabled: true
-        storageClassName: ceph-block
+        storageClassName: scale-nvmeof
         size: 500Gi
       retentionPeriod: 14d
       serviceMonitor:

--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -99,7 +99,7 @@ spec:
         storage:
           accessModes:
             - ReadWriteOnce
-          storageClassName: ceph-block
+          storageClassName: scale-nvmeof
           resources:
             requests:
               storage: 300Gi
@@ -137,7 +137,7 @@ spec:
             spec:
               accessModes:
                 - ReadWriteOnce
-              storageClassName: ceph-block
+              storageClassName: scale-nvmeof
               resources:
                 requests:
                   storage: 2Gi


### PR DESCRIPTION
Phase 2: flips the 5 observability storage refs (vmsingle 300Gi, vmalertmanager 2x2Gi, victoria-logs 500Gi, grafana 20Gi, gatus 15Gi) to scale-nvmeof. Volumes recreate EMPTY per the approved start-fresh decision (dashboards re-provision from GrafanaDashboard CRs). STS VCTs immutable -> workloads deleted+recreated during cutover.