### PR TITLE
migrate(phase3): netbox-postgres -> scale-nvmeof (Barman recovery)

### DIFF
--- a/kubernetes/apps/database/netbox-postgres/app/cluster.yaml
+++ b/kubernetes/apps/database/netbox-postgres/app/cluster.yaml
@@ -27,7 +27,7 @@ spec:
   # Storage configuration
   storage:
     size: 10Gi
-    storageClass: ceph-block
+    storageClass: scale-nvmeof
 
   # Resource limits
   resources:


### PR DESCRIPTION
Phase 3. Uses the manifest's own DR model (bootstrap.recovery + skipEmptyWalArchiveCheck, proven in the Flatcar rebuild): netbox scaled to 0, final backup completed, old cluster deleted; merging this recreates the cluster on scale-nvmeof via recovery from TrueNAS S3. Fingerprint captured for post-recovery verification.