### PR TITLE
migrate(phase4/5-prep): drop netbox RWX volsync + de-Rook app dependsOn

### DIFF
--- a/kubernetes/apps/auth/pocket-id/ks.yaml
+++ b/kubernetes/apps/auth/pocket-id/ks.yaml
@@ -10,8 +10,6 @@ spec:
   dependsOn:
     - name: external-secrets
       namespace: external-secrets
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/auth/pocket-id/app
   postBuild:

--- a/kubernetes/apps/automation/n8n/ks.yaml
+++ b/kubernetes/apps/automation/n8n/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/volsync
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/automation/n8n/app
   postBuild:

--- a/kubernetes/apps/database/netbox-postgres/ks.yaml
+++ b/kubernetes/apps/database/netbox-postgres/ks.yaml
@@ -13,8 +13,6 @@ spec:
     - name: cloudnative-pg
     - name: external-secrets
       namespace: external-secrets
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/database/netbox-postgres/app
   prune: true

--- a/kubernetes/apps/downloads/autobrr/ks.yaml
+++ b/kubernetes/apps/downloads/autobrr/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/nfs-scaler
     - ../../../../components/volsync
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/downloads/autobrr/app
   postBuild:

--- a/kubernetes/apps/downloads/bazarr/ks.yaml
+++ b/kubernetes/apps/downloads/bazarr/ks.yaml
@@ -9,8 +9,6 @@ spec:
     - ../../../../components/nfs-scaler
     - ../../../../components/volsync
   dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
     - name: keda
       namespace: observability
   interval: 1h

--- a/kubernetes/apps/downloads/nzbget/ks.yaml
+++ b/kubernetes/apps/downloads/nzbget/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/nfs-scaler
     - ../../../../components/volsync
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/downloads/nzbget/app
   postBuild:

--- a/kubernetes/apps/downloads/pinchflat/ks.yaml
+++ b/kubernetes/apps/downloads/pinchflat/ks.yaml
@@ -9,8 +9,6 @@ spec:
     - ../../../../components/nfs-scaler
     - ../../../../components/volsync
   dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
     - name: keda
       namespace: observability
   interval: 1h

--- a/kubernetes/apps/downloads/prowlarr/ks.yaml
+++ b/kubernetes/apps/downloads/prowlarr/ks.yaml
@@ -9,8 +9,6 @@ spec:
     - ../../../../components/nfs-scaler
     - ../../../../components/volsync
   dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
     - name: keda
       namespace: observability
   interval: 1h

--- a/kubernetes/apps/downloads/qbittorrent/ks.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/ks.yaml
@@ -9,8 +9,6 @@ spec:
     - ../../../../components/nfs-scaler
     - ../../../../components/volsync
   dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
     - name: keda
       namespace: observability
   interval: 1h

--- a/kubernetes/apps/downloads/qui/ks.yaml
+++ b/kubernetes/apps/downloads/qui/ks.yaml
@@ -9,8 +9,6 @@ spec:
     - ../../../../components/nfs-scaler
     - ../../../../components/volsync
   dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
     - name: qbittorrent
       namespace: downloads
   interval: 1h

--- a/kubernetes/apps/downloads/radarr/ks.yaml
+++ b/kubernetes/apps/downloads/radarr/ks.yaml
@@ -9,8 +9,6 @@ spec:
     - ../../../../components/nfs-scaler
     - ../../../../components/volsync
   dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
     - name: keda
       namespace: observability
   interval: 1h

--- a/kubernetes/apps/downloads/recyclarr/ks.yaml
+++ b/kubernetes/apps/downloads/recyclarr/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/volsync
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/downloads/recyclarr/app
   postBuild:

--- a/kubernetes/apps/downloads/sonarr/ks.yaml
+++ b/kubernetes/apps/downloads/sonarr/ks.yaml
@@ -9,8 +9,6 @@ spec:
     - ../../../../components/nfs-scaler
     - ../../../../components/volsync
   dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
     - name: keda
       namespace: observability
   interval: 1h

--- a/kubernetes/apps/media/seerr/ks.yaml
+++ b/kubernetes/apps/media/seerr/ks.yaml
@@ -11,8 +11,6 @@ spec:
   dependsOn:
     - name: keda
       namespace: observability
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/media/seerr/app
   postBuild:

--- a/kubernetes/apps/observability/gatus/ks.yaml
+++ b/kubernetes/apps/observability/gatus/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: gatus
 spec:
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/observability/gatus/app
   prune: true

--- a/kubernetes/apps/observability/grafana/ks.yaml
+++ b/kubernetes/apps/observability/grafana/ks.yaml
@@ -28,8 +28,6 @@ metadata:
 spec:
   dependsOn:
     - name: grafana
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/observability/grafana/instance
   prune: true

--- a/kubernetes/apps/observability/victoria-logs/ks.yaml
+++ b/kubernetes/apps/observability/victoria-logs/ks.yaml
@@ -22,8 +22,6 @@ metadata:
   name: victoria-logs
 spec:
   dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
     - name: victoria-logs-rules
   interval: 1h
   path: ./kubernetes/apps/observability/victoria-logs/app

--- a/kubernetes/apps/observability/victoria-metrics/ks.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: victoria-metrics
 spec:
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/observability/victoria-metrics/app
   postBuild:

--- a/kubernetes/apps/self-hosted/actual/ks.yaml
+++ b/kubernetes/apps/self-hosted/actual/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/volsync
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/self-hosted/actual/app
   postBuild:

--- a/kubernetes/apps/self-hosted/atuin/ks.yaml
+++ b/kubernetes/apps/self-hosted/atuin/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/volsync
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/self-hosted/atuin/app
   postBuild:

--- a/kubernetes/apps/self-hosted/freshrss/ks.yaml
+++ b/kubernetes/apps/self-hosted/freshrss/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/volsync
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/self-hosted/freshrss/app
   postBuild:

--- a/kubernetes/apps/self-hosted/netbox/ks.yaml
+++ b/kubernetes/apps/self-hosted/netbox/ks.yaml
@@ -9,24 +9,16 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  components:
-    - ../../../../components/volsync
   dependsOn:
     - name: external-secrets
       namespace: external-secrets
     - name: netbox-postgres
       namespace: database
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/self-hosted/netbox/app
   postBuild:
     substitute:
       APP: netbox
-      VOLSYNC_CAPACITY: 10Gi
-      VOLSYNC_STORAGECLASS: ceph-filesystem
-      VOLSYNC_SNAPSHOTCLASS: csi-ceph-filesystem
-      VOLSYNC_ACCESSMODES: ReadWriteMany
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
Phase 4 + Phase-5 prep. netbox's RWX ceph-filesystem PVC verified EMPTY (0 files, unmounted; data is in CNPG, fingerprint-verified) -> volsync component removed, Flux prunes PVC/RS/RD. Removes rook-ceph-cluster dependsOn from all 22 app ks.yaml (all apps now on scale-csi) so Phase-5 Rook removal can't wedge them. NOTE: untracked WIP claude-remote/ks.yaml also references rook-ceph-cluster and needs the same fix before commit.