### PR TITLE
migrate(phase5-prep): volsync + default SC -> scale-nvmeof

### DIFF
--- a/kubernetes/apps/scale-csi/scale-csi/app/helmrelease.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/helmrelease.yaml
@@ -46,7 +46,7 @@ spec:
     storageClasses:
       - name: scale-nvmeof
         protocol: nvmeof
-        isDefault: false
+        isDefault: true
         reclaimPolicy: Delete
         allowVolumeExpansion: true
         volumeBindingMode: Immediate

--- a/kubernetes/components/volsync/pvc.yaml
+++ b/kubernetes/components/volsync/pvc.yaml
@@ -13,4 +13,4 @@ spec:
   resources:
     requests:
       storage: ${VOLSYNC_CAPACITY:=5Gi}
-  storageClassName: ${VOLSYNC_STORAGECLASS:=ceph-block}
+  storageClassName: ${VOLSYNC_STORAGECLASS:=scale-nvmeof}

--- a/kubernetes/components/volsync/replicationdestination.yaml
+++ b/kubernetes/components/volsync/replicationdestination.yaml
@@ -34,5 +34,5 @@ spec:
     repository: ${APP}-volsync-secret
     sourceIdentity:
       sourceName: ${APP}
-    storageClassName: ${VOLSYNC_STORAGECLASS:=ceph-block}
-    volumeSnapshotClassName: ${VOLSYNC_SNAPSHOTCLASS:=csi-ceph-blockpool}
+    storageClassName: ${VOLSYNC_STORAGECLASS:=scale-nvmeof}
+    volumeSnapshotClassName: ${VOLSYNC_SNAPSHOTCLASS:=scale-snapshot}

--- a/kubernetes/components/volsync/replicationsource.yaml
+++ b/kubernetes/components/volsync/replicationsource.yaml
@@ -32,5 +32,5 @@ spec:
     retain:
       hourly: 24
       daily: 7
-    storageClassName: ${VOLSYNC_STORAGECLASS:=ceph-block}
-    volumeSnapshotClassName: ${VOLSYNC_SNAPSHOTCLASS:=csi-ceph-blockpool}
+    storageClassName: ${VOLSYNC_STORAGECLASS:=scale-nvmeof}
+    volumeSnapshotClassName: ${VOLSYNC_SNAPSHOTCLASS:=scale-snapshot}


### PR DESCRIPTION
Non-destructive Phase-5 prep: VolSync component fallback classes and the cluster default StorageClass move to scale-nvmeof before Rook is decommissioned.