### PR TITLE
feat(observability): scrape scale-csi metrics + de-Ceph kromgo panels

### DIFF
--- a/kubernetes/apps/observability/kromgo/app/resources/config.yaml
+++ b/kubernetes/apps/observability/kromgo/app/resources/config.yaml
@@ -75,6 +75,25 @@ metrics:
       - {color: "red", min: 1, max: 9999}
     title: Alerts
 
+  - name: storage_health
+    query: >-
+      (label_replace(scale_csi_truenas_connection_status, "health", "OK", "", "") and on() (scale_csi_truenas_connection_status == 1))
+      or (label_replace(scale_csi_truenas_connection_status, "health", "DOWN", "", "") and on() (scale_csi_truenas_connection_status == 0))
+    label: health
+    colors:
+      - {color: "green", min: 1, max: 1}
+      - {color: "red", min: 0, max: 0}
+    title: Storage
+
+  - name: storage_used
+    query: round(100 * sum(kubelet_volume_stats_used_bytes) / sum(kubelet_volume_stats_capacity_bytes), 0.1)
+    suffix: "%"
+    colors:
+      - {color: "green", min: 0, max: 60}
+      - {color: "orange", min: 61, max: 85}
+      - {color: "red", min: 86, max: 9999}
+    title: PVC Used
+
   - name: cert_expiry_days
     query: round(min(certmanager_certificate_expiration_timestamp_seconds - time()) / 86400)
     suffix: "d"

--- a/kubernetes/apps/scale-csi/scale-csi/app/kustomization.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
   - ./ocirepository.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./vmservicescrape.yaml
+  - ./vmrule.yaml

--- a/kubernetes/apps/scale-csi/scale-csi/app/vmrule.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/vmrule.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schema.pages.dev/operator.victoriametrics.com/vmrule_v1beta1.json
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  name: scale-csi-rules
+spec:
+  groups:
+    - name: scale-csi.rules
+      rules:
+        - alert: ScaleCSITrueNASConnectionDown
+          expr: |-
+            scale_csi_truenas_connection_status == 0
+          for: 5m
+          annotations:
+            summary: >-
+              scale-csi controller has lost its TrueNAS API connection — provisioning,
+              attach and delete operations will fail until it reconnects
+          labels:
+            severity: critical
+        - alert: ScaleCSIOrphanedBackendObjects
+          expr: |-
+            (scale_csi_orphan_volumes > 0) or (scale_csi_orphan_snapshots > 0)
+          for: 2h5m
+          annotations:
+            summary: >-
+              scale-csi reconcile detected {{ $value }} orphaned backend object(s) on
+              TrueNAS with no live Kubernetes owner — the nightly gated GC will clean
+              them once aged, or investigate with the driver's reconcile report
+          labels:
+            severity: warning

--- a/kubernetes/apps/scale-csi/scale-csi/app/vmservicescrape.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/vmservicescrape.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schema.pages.dev/operator.victoriametrics.com/vmservicescrape_v1beta1.json
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  name: scale-csi-controller
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: scale-csi
+      app.kubernetes.io/component: controller
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+---
+# Node metrics (per-node iSCSI/NVMe session gauges + connect counters)
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  name: scale-csi-node
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: scale-csi
+      app.kubernetes.io/component: node
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s

--- a/scripts/cloudflare-worker/kromgo-proxy/src/index.js
+++ b/scripts/cloudflare-worker/kromgo-proxy/src/index.js
@@ -143,8 +143,8 @@ const METRIC_ICON_MAP = {
   container_count: "container",
   cluster_cpu_usage: "cpu",
   cluster_memory_usage: "ram",
-  ceph_storage_used: "storage",
-  ceph_health: "shieldcheck",
+  storage_used: "storage",
+  storage_health: "shieldcheck",
   helmrelease_count: "helm",
   pvc_count: "volume",
   flux_failing_count: "xerror",
@@ -157,8 +157,8 @@ const METRIC_ICON_MAP = {
 // Metrics whose value carries a real state — these render a status dot.
 // Plain counts and facts (nodes, pods, age, versions) stay neutral.
 const METRIC_STATUS = new Set([
-  "cluster_alert_count", "ceph_health", "cluster_cpu_usage",
-  "cluster_memory_usage", "ceph_storage_used", "cert_expiry_days",
+  "cluster_alert_count", "storage_health", "cluster_cpu_usage",
+  "cluster_memory_usage", "storage_used", "cert_expiry_days",
   "flux_failing_count", "renovate", "wan_primary", "wan_cellular1",
   "wan_cellular2",
 ]);
@@ -350,7 +350,7 @@ const ALLOWED_METRICS = new Set([
   "talos_version", "kubernetes_version", "flux_version",
   "cluster_node_count", "cluster_pod_count", "cluster_cpu_usage",
   "cluster_memory_usage", "cluster_age_days", "cluster_uptime_days",
-  "cluster_alert_count", "ceph_storage_used", "ceph_health",
+  "cluster_alert_count", "storage_used", "storage_health",
   "cert_expiry_days", "flux_failing_count", "helmrelease_count",
   "pvc_count", "container_count", "wan_primary", "wan_cellular1", "wan_cellular2",
   "network_status", "renovate", "stack_panel", "health_panel",
@@ -491,7 +491,7 @@ const PANEL_DEFINITIONS = {
       { metric: "cluster_age_days", label: "Age", hue: "violet" },
       { metric: "cluster_uptime_days", label: "Uptime", hue: "cyan" },
       { metric: "cluster_alert_count", label: "Alerts", status: true },
-      { metric: "ceph_health", label: "Ceph", status: true },
+      { metric: "storage_health", label: "Storage", status: true },
     ],
   },
   usage_panel: {
@@ -500,7 +500,7 @@ const PANEL_DEFINITIONS = {
       { metric: "container_count", label: "Containers", hue: "teal" },
       { metric: "cluster_cpu_usage", label: "CPU", status: true },
       { metric: "cluster_memory_usage", label: "Memory", status: true },
-      { metric: "ceph_storage_used", label: "Storage", status: true },
+      { metric: "storage_used", label: "PVC Used", status: true },
     ],
   },
   gitops_panel: {


### PR DESCRIPTION
Wires scale_csi_* into VictoriaMetrics (VMServiceScrape — nothing was scraping the driver), adds connection-down + orphan alerts (VMRule), and replaces the dead ceph kromgo metrics/panels with storage_health + storage_used. Worker redeploy needed after merge for the badge panels.