### PR TITLE
fix(nzbget): ArticleCache 12GB (cache-cap throttling at 5Gbps)

### DIFF
--- a/kubernetes/apps/downloads/nzbget/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/nzbget/app/helmrelease.yaml
@@ -118,7 +118,7 @@ spec:
             DaemonUsername=root
 
             # Performance — Download
-            ArticleCache=4000
+            ArticleCache=12000
             DirectWrite=yes
             DirectRename=yes
             DirectUnpack=yes


### PR DESCRIPTION
Instrumented probe showed cacheMB pinned at 3999/4000 for the entire large download while rate decayed 457->339 with postJobs=0 — pure ArticleCache backpressure (intake ~541MB/s vs flush ~450MB/s). 12GB absorbs the gap so big downloads hold line rate. Live config gets the same change via RPC after the in-flight download completes.