### PR TITLE
fix(observability): correct two never-evaluated alert rules

### DIFF
--- a/kubernetes/apps/network/cloudflare-dns/app/vmrule.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/app/vmrule.yaml
@@ -8,12 +8,18 @@ spec:
   groups:
     - name: external-dns.rules
       rules:
+        # 2026-07-21: both external-dns instances run --interval=1h --events, so a
+        # last-sync gap of up to 1h is normal quiet-period behavior. The original 60s
+        # threshold would have fired permanently (it never evaluated before 2026-07-21
+        # because vmalert wasn't loading cross-namespace VMRules). 2h = two missed
+        # full sync cycles = genuinely stuck controller.
         - alert: ExternalDNSStale
           expr: |-
-            time() - external_dns_controller_last_sync_timestamp_seconds > 60
+            time() - external_dns_controller_last_sync_timestamp_seconds > 7200
           for: 10m
           annotations:
             summary: >-
-              ExternalDNS ({{ $labels.job }}) has not synced successfully in the last ten minutes
+              ExternalDNS ({{ $labels.job }}) has not synced for over two hours
+              (sync interval is 1h) — new/changed service records are not being published
           labels:
             severity: critical

--- a/kubernetes/apps/observability/victoria-metrics/app/vmrule-infrastructure.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/vmrule-infrastructure.yaml
@@ -391,16 +391,23 @@ spec:
             severity: warning
             component: infrastructure
 
+        # 2026-07-21: made ZFS-ARC-aware. nas01's ARC (~75 GiB, c_max ≈ all RAM) is
+        # reclaimable-on-demand cache the kernel does NOT count in MemAvailable, so the
+        # naive expr reads a permanently-healthy TrueNAS box as >90% used and would fire
+        # forever. Adding node_zfs_arc_size back to "available" (or 0 on non-ZFS hosts)
+        # measures real memory pressure on every host.
         - alert: ExternalHostHighMemory
           expr: |-
-            (1 - (node_memory_MemAvailable_bytes{job="node-exporter"} / node_memory_MemTotal_bytes{job="node-exporter"})) * 100 > 90
+            (1 - ((node_memory_MemAvailable_bytes{job="node-exporter"}
+              + (node_zfs_arc_size{job="node-exporter"} or 0 * node_memory_MemAvailable_bytes{job="node-exporter"}))
+              / node_memory_MemTotal_bytes{job="node-exporter"})) * 100 > 90
           for: 15m
           keep_firing_for: 5m
           annotations:
-            summary: "Host {{ $labels.instance }} memory usage is {{ $value | humanize }}%"
+            summary: "Host {{ $labels.instance }} memory usage is {{ $value | humanize }}% (ARC-adjusted)"
             description: |-
-              Memory on {{ $labels.instance }} has been above 90% for 15 minutes.
-              Risk of OOM kills.
+              Memory on {{ $labels.instance }} has been above 90% for 15 minutes
+              (ZFS ARC counted as reclaimable). Risk of OOM kills.
           labels:
             severity: warning
             component: infrastructure


### PR DESCRIPTION
Both surfaced as instant false-positives when #1402 made vmalert load
cross-namespace VMRules for the first time:

- ExternalDNSStale: threshold 60s -> 2h. Both external-dns instances run
  --interval=1h --events, so sub-hour staleness is normal quiet-period
  behavior; the 60s threshold fired within minutes of the rule going live.
- ExternalHostHighMemory: made ZFS-ARC-aware. nas01's ARC (~75 GiB,
  reclaimable) isn't counted in MemAvailable, reading a healthy box as
  92% used; ARC-adjusted real usage is 46%. Non-ZFS hosts unaffected
  via the or-0 fallback (validated live: 11/11 hosts still present).
