### PR TITLE
fix(scale-csi): harden ops — TLS verify, NFS /32 allowlist, GC cap, new alerts

### DIFF
--- a/kubernetes/apps/scale-csi/scale-csi/app/helmrelease.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/helmrelease.yaml
@@ -11,10 +11,10 @@ spec:
   interval: 1h
   values:
     truenas:
-      host: "192.168.120.10"
+      host: "nas01.${SECRET_DOMAIN}"
       port: 443
       secure: true
-      skipTLSVerify: true
+      skipTLSVerify: false
       existingSecret: scale-csi-secret
     zfs:
       parentDataset: flashstor/scale-csi
@@ -27,7 +27,9 @@ spec:
       enabled: true
       server: "192.168.120.10"
       shareAllowedNetworks:
-        - 192.168.120.0/22
+        - 192.168.122.10/32
+        - 192.168.122.11/32
+        - 192.168.122.12/32
     iscsi:
       enabled: true
       portal: "192.168.120.10:3260"
@@ -72,6 +74,7 @@ spec:
     reconcile:
       delete:
         # Gated GC: nightly CronJob releases spent VolSync-restore snapshots and
-        # deletes true orphans (>24h old, capped 5/run, guarded delete paths,
+        # deletes true orphans (>24h old, capped 20/run, guarded delete paths,
         # fails closed during cluster rebuilds). Detection/alerting is always on.
         enabled: true
+        maxPerRun: 20

--- a/kubernetes/apps/scale-csi/scale-csi/app/vmrule.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/vmrule.yaml
@@ -29,3 +29,46 @@ spec:
               them once aged, or investigate with the driver's reconcile report
           labels:
             severity: warning
+        - alert: ScaleCSIControllerMetricsAbsent
+          expr: |-
+            absent(scale_csi_truenas_connection_status{job="scale-csi-controller-metrics"}) == 1
+          for: 10m
+          annotations:
+            summary: >-
+              scale-csi controller metrics have vanished — the controller is down or
+              its scrape target is broken; no provisioning or GC activity is observable
+          labels:
+            severity: critical
+        - alert: ScaleCSISustainedOperationErrors
+          expr: |-
+            sum by (operation, code) (rate(scale_csi_operations_total{job="scale-csi-controller-metrics",status="error",code!~"FailedPrecondition|AlreadyExists|Aborted"}[10m])) > 0.02
+          for: 15m
+          annotations:
+            summary: >-
+              scale-csi is sustaining unexpected-code operation failures ({{ $value }}/s
+              by operation/code) — expected lifecycle rejections are excluded; investigate
+              the controller logs for the failing operations
+          labels:
+            severity: warning
+        - alert: ScaleCSISpentRestoreBacklog
+          expr: |-
+            max(scale_csi_spent_restore_snapshots{job="scale-csi-controller-metrics"}) > 0
+          for: 48h
+          annotations:
+            summary: >-
+              spent VolSync-restore snapshots have outlived the nightly GC window —
+              the gated delete CronJob may be failing or the snapshots are not ageing
+              out as expected
+          labels:
+            severity: warning
+        - alert: ScaleCSISessionGCDisconnects
+          expr: |-
+            increase(scale_csi_gc_sessions_disconnected_total[1h]) > 0
+          for: 5m
+          annotations:
+            summary: >-
+              session GC disconnected {{ $value }} session(s) in the last hour — verify
+              these were truly orphaned and not active volumes affected by a pod churn
+              or node restart race
+          labels:
+            severity: warning


### PR DESCRIPTION
Adversarial-audit ops hardening (F-08/F-09/F-14/F-18): TrueNAS TLS certificate verification on (host via SECRET_DOMAIN substitution), NFS exports narrowed to the three K8s node /32s, nightly GC delete cap 5→20, four new alerts (controller-metrics-absent, sustained unexpected-code op errors, spent-restore backlog, session-GC disconnects).