### PR TITLE
chore(scale-csi): bump chart to 1.2.23 (backend fencing batch, fencing.mode defaults off)

### DIFF
--- a/kubernetes/apps/scale-csi/scale-csi/app/ocirepository.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.2.22
+    tag: 1.2.23
   url: oci://ghcr.io/gizmotickler/charts/scale-csi


### PR DESCRIPTION
Co-authored-by: Qwen-Coder <qwen-coder@alibabacloud.com>
