### PR TITLE
chore(scale-csi): bump chart to 1.2.28 (maintainability refactors — provenance extraction, unified property writes, ShareBackend interface, spentRestore gate)

### DIFF
--- a/kubernetes/apps/scale-csi/scale-csi/app/ocirepository.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.2.27
+    tag: 1.2.28
   url: oci://ghcr.io/gizmotickler/charts/scale-csi


### PR DESCRIPTION
Chart bump 1.2.27 → 1.2.28.

Batch 13 maintainability refactors, all independently verified behavior-preserving (mechanical diff audit + full -race suite + golden API-call-count tests):
- provenance machinery extracted from controller.go to provenance.go (pure move)
- stampAndMirror: single property-write idiom (same wire calls)
- ShareBackend interface replaces scattered protocol switches (defaults and fence-arg subsets preserved)
- reconcile.spentRestore.enabled config gate (default true = current behavior)

No CRD/values migration required; default values preserve v1.2.27 behavior.