### PR TITLE
fix(scale-csi): raise controller memory limit 256Mi->1Gi (OOM crash loop)

### DIFF
--- a/kubernetes/apps/scale-csi/scale-csi/app/helmrelease.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/helmrelease.yaml
@@ -10,6 +10,19 @@ spec:
     name: scale-csi
   interval: 1h
   values:
+    # 2026-07-22 OOM incident: chart-default 256Mi controller limit is too small —
+    # zfs.resource.snapshot.query returns ~29MB JSON per call at current snapshot
+    # count (inherited tombstone-ledger props amplify every entry), and concurrent
+    # VolSync CreateVolume-from-snapshot + strict-fencing startup reconcile pushed
+    # the heap past the limit (crash loop, 12 restarts). 1Gi is headroom until the
+    # batch-14 driver fix (single-fetch + ledger relocation) lands.
+    controller:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 128Mi
+        limits:
+          memory: 1Gi
     # Backend publication fencing. strict = backend allowlists converge to CSI
     # publications only (static subsystemHosts ignored for fenced volumes);
     # flipped 2026-07-22 after additive verification (27/27 converged,


### PR DESCRIPTION
Controller is in an OOM crash loop (12 restarts/130m, exit 137 at 23:28Z): ~29MB zfs.resource.snapshot.query payloads (inherited tombstone-ledger property amplification, 289 snapshots) x concurrent VolSync CreateVolume-from-snapshot retries x strict-fencing startup reconcile exceed the chart-default 256Mi limit. Fleet-wide hourly VolSync backups are wedged (volsync-*-src PVCs Pending). Interim mitigation; driver-side fix is batch 14 (under adversarial review).