### PR TITLE
feat(scale-csi): bump chart to 1.2.31 (batch 14) + enable bookkeeping relocation

### DIFF
--- a/kubernetes/apps/scale-csi/scale-csi/app/helmrelease.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/helmrelease.yaml
@@ -97,6 +97,16 @@ spec:
       name: scale-snapshot
       deletionPolicy: Delete
     reconcile:
+      # 2026-07-23: relocate tombstone ledger + in-flight markers off the
+      # inheritable parent dataset (v1.2.30 batch 14). Root cause of the
+      # 2026-07-22 controller OOM loop: dependent-clone deferred deletes wrote
+      # ledger entries (+16/h) as inheritable parent properties, so every
+      # snapshot carried the full ledger -> 35MB snapshot-query payloads.
+      # Writes go to a non-inheriting .csi-bookkeeping child with lossless
+      # dual-read migration; cleanupParent stays default-off for first soak
+      # (parent entries dual-read until explicitly cleaned).
+      bookkeeping:
+        enabled: true
       delete:
         # Gated GC: nightly CronJob releases spent VolSync-restore snapshots and
         # deletes true orphans (>24h old, capped 20/run, guarded delete paths,

--- a/kubernetes/apps/scale-csi/scale-csi/app/helmrelease.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/helmrelease.yaml
@@ -98,7 +98,7 @@ spec:
       deletionPolicy: Delete
     reconcile:
       # 2026-07-23: relocate tombstone ledger + in-flight markers off the
-      # inheritable parent dataset (v1.2.30 batch 14). Root cause of the
+      # inheritable parent dataset (v1.2.31 batch 14). Root cause of the
       # 2026-07-22 controller OOM loop: dependent-clone deferred deletes wrote
       # ledger entries (+16/h) as inheritable parent properties, so every
       # snapshot carried the full ledger -> 35MB snapshot-query payloads.

--- a/kubernetes/apps/scale-csi/scale-csi/app/ocirepository.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.2.28
+    tag: 1.2.30
   url: oci://ghcr.io/gizmotickler/charts/scale-csi

--- a/kubernetes/apps/scale-csi/scale-csi/app/ocirepository.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.2.30
+    tag: 1.2.31
   url: oci://ghcr.io/gizmotickler/charts/scale-csi


### PR DESCRIPTION
## What
- OCIRepository ref.tag: 1.2.28 -> **1.2.30** (batch 14, Opus-verified; v1.2.29 tag was superseded by a lint-only fix, no artifacts published)
- **reconcile.bookkeeping.enabled: true** — relocates the tombstone ledger + in-flight markers to a non-inheriting `.csi-bookkeeping` child dataset with lossless dual-read migration. `cleanupParent` stays default-off for the first soak.

## Why
Root-cause fix for the 2026-07-22 controller OOM crash loop: the dependent-clone revert generated +16 deferred-delete ledger entries/hour as inheritable parent-dataset properties, so every snapshot carried the full ledger — snapshot-query payloads grew 29->35MB in 2h and blew the 256Mi limit during concurrent VolSync CreateVolume ops. The 1Gi limit (#1420) is the stopgap; this is the fix.

Batch 14 also ships: transport-error retry classification (breaker no longer records false success), debouncer starvation fix, inherited-property orphan classifier guard, snapshot single-fetch (O(N²) removed), GC sweep/canonical-teardown parity, spent-restore Pending/Lost PVC guard.

## Verification
Full adversarial cycle: Fable+Qwen dual review -> Qwen implementation -> Opus adversarial verification (1 blocker found+fixed+regression-tested) -> fresh `-race` gauntlet green. Regression tests proven to fail on v1.2.28.

## Post-merge watch
- Controller logs: one-time ledger migration lines on first reconcile pass
- `zfs.resource.snapshot.query` payload should collapse ~100x after tonight's GC reaps the parent-side backlog
- Ledger gauge: scale_csi_tombstone_snapshots