### PR TITLE
chore(scale-csi): bump chart to 1.2.32 (bookkeeping migration chunking)

### DIFF
--- a/kubernetes/apps/scale-csi/scale-csi/app/ocirepository.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.2.31
+    tag: 1.2.32
   url: oci://ghcr.io/gizmotickler/charts/scale-csi


### PR DESCRIPTION
Driver-only fix, no values changes. v1.2.31's one-time bookkeeping migration copied the ~300-entry backlog in a single pool.dataset.update, exceeding TrueNAS's 64kB WebSocket inbound limit (close 1009). The copy actually landed (all 321 entries verified LOCAL on .csi-bookkeeping), but with cleanupParent=false every reconcile pass re-copies and errors identically — hourly failure-metric noise until deployed. v1.2.32 makes the migration idempotent-skip (steady-state = zero writes) + chunked (<=32kB batches, ~2x wire headroom). Opus-verified SHIP with mutation-tested regression coverage.