### PR TITLE
chore(scale-csi): bump chart to 1.2.33 (batch 15 — marker-based remnant-orphan GC)

### DIFF
--- a/kubernetes/apps/scale-csi/scale-csi/app/ocirepository.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.2.32
+    tag: 1.2.33
   url: oci://ghcr.io/gizmotickler/charts/scale-csi


### PR DESCRIPTION
Driver-only, no values changes. Batch 15 (Opus-verified, D1 lock fix mutation-tested): interrupted-create remnants (marker-proven, unstamped, aged >minOrphanAge, no live PV/VA) are now classified and — under the existing gated delete mode — safely reaped with nonce/origin/stamp/lock guards. Automates the manual zombie cleanup from the 2026-07-23 OOM incident. Also: .csi-bookkeeping inbound-ID guard, new scale_csi_remnant_volumes gauge, downgrade docs.