### PR TITLE
chore(scale-csi): bump chart to 1.2.34 (batch 16 — legacy stamp adoption)

### DIFF
--- a/kubernetes/apps/scale-csi/scale-csi/app/ocirepository.yaml
+++ b/kubernetes/apps/scale-csi/scale-csi/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.2.33
+    tag: 1.2.34
   url: oci://ghcr.io/gizmotickler/charts/scale-csi


### PR DESCRIPTION
Driver-only, no values changes. Migration-era volumes (pre-v1.2.21) lack driver_instance_id, so the tombstone reaper refuses their tombstones forever — verified live at the 2026-07-23 04:00Z GC run. v1.2.34 adds a guarded adoption pass: stamps ONLY datasets with source-bearing LOCAL managed_resource + csi_volume_name matching the leaf, NO existing stamp of any source (never overwrites — local/inherited/foreign), and a live Bound PV of this driver (empty-list fail-safe), capped per pass, written under the per-volume lock with verify re-read. Opus-verified SHIP with mutation-tested guards.

**Merging before tonight's 04:00Z GC lets it adopt the legacy volumes and drain the entire aged ledger backlog (~300 entries + their -csi-deleted- snapshots) in one pass.**