### PR TITLE
fix(homeops-cli): unbreak Go test job from Renovate version drift

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -32,6 +32,9 @@
     "**/resources/**",
     "cmd/**/templates/volsync/**",
     "archive/**",
+    // Go test fixtures and golden files pin versions on purpose; bumping them
+    // desyncs the checked-in expectations and breaks the Go test job.
+    "**/testdata/**",
   ],
   packageRules: [
     {

--- a/cmd/homeops-cli/cmd/kubernetes/etcd_restore_test.go
+++ b/cmd/homeops-cli/cmd/kubernetes/etcd_restore_test.go
@@ -240,9 +240,29 @@ func TestExtractEtcdImageRefFromManifestFixture(t *testing.T) {
 	require.NoError(t, err)
 	image, err := extractEtcdImageRef(raw)
 	require.NoError(t, err)
-	assert.Equal(t, "registry.k8s.io/etcd:3.7.0-0", image)
+	// The fixture is a real manifest that Renovate keeps current, so assert on
+	// shape rather than a pinned tag. Container selection is covered below.
+	assert.Regexp(t, `^registry\.k8s\.io/etcd:\S+$`, image)
 
 	_, err = extractEtcdImageRef([]byte("spec:\n  containers:\n    - name: sidecar\n      image: example.invalid/sidecar:1\n"))
+	require.Error(t, err)
+}
+
+func TestExtractEtcdImageRefSelectsEtcdContainer(t *testing.T) {
+	manifest := []byte(`spec:
+  containers:
+    - name: sidecar
+      image: example.invalid/sidecar:1
+    - name: etcd
+      image: registry.k8s.io/etcd:9.9.9-0
+    - name: trailing
+      image: example.invalid/trailing:2
+`)
+	image, err := extractEtcdImageRef(manifest)
+	require.NoError(t, err)
+	assert.Equal(t, "registry.k8s.io/etcd:9.9.9-0", image)
+
+	_, err = extractEtcdImageRef([]byte("spec:\n  containers:\n    - name: etcd\n      image: \"   \"\n"))
 	require.Error(t, err)
 }
 

--- a/cmd/homeops-cli/internal/templates/testdata/golden/talos/controlplane.yaml-192.168.122.10.yaml
+++ b/cmd/homeops-cli/internal/templates/testdata/golden/talos/controlplane.yaml-192.168.122.10.yaml
@@ -122,7 +122,7 @@ machine:
           permissions: 420
     install:
         disk: /dev/sda
-        image: factory.talos.dev/installer/c682c3b7e2747ecadb2b2f9eb73336e40373cfbe6f7ec588336ece6f3a1059cf:v1.13.8
+        image: factory.talos.dev/installer/c682c3b7e2747ecadb2b2f9eb73336e40373cfbe6f7ec588336ece6f3a1059cf:v1.13.7
         wipe: false
     kernel:
         modules:

--- a/cmd/homeops-cli/internal/templates/testdata/golden/talos/controlplane.yaml-192.168.122.11.yaml
+++ b/cmd/homeops-cli/internal/templates/testdata/golden/talos/controlplane.yaml-192.168.122.11.yaml
@@ -122,7 +122,7 @@ machine:
           permissions: 420
     install:
         disk: /dev/sda
-        image: factory.talos.dev/installer/c682c3b7e2747ecadb2b2f9eb73336e40373cfbe6f7ec588336ece6f3a1059cf:v1.13.8
+        image: factory.talos.dev/installer/c682c3b7e2747ecadb2b2f9eb73336e40373cfbe6f7ec588336ece6f3a1059cf:v1.13.7
         wipe: false
     kernel:
         modules:

--- a/cmd/homeops-cli/internal/templates/testdata/golden/talos/controlplane.yaml-192.168.122.12.yaml
+++ b/cmd/homeops-cli/internal/templates/testdata/golden/talos/controlplane.yaml-192.168.122.12.yaml
@@ -122,7 +122,7 @@ machine:
           permissions: 420
     install:
         disk: /dev/sda
-        image: factory.talos.dev/installer/c682c3b7e2747ecadb2b2f9eb73336e40373cfbe6f7ec588336ece6f3a1059cf:v1.13.8
+        image: factory.talos.dev/installer/c682c3b7e2747ecadb2b2f9eb73336e40373cfbe6f7ec588336ece6f3a1059cf:v1.13.7
         wipe: false
     kernel:
         modules:

--- a/cmd/homeops-cli/internal/templates/testdata/golden/talos/worker.yaml-192.168.122.10.yaml
+++ b/cmd/homeops-cli/internal/templates/testdata/golden/talos/worker.yaml-192.168.122.10.yaml
@@ -59,7 +59,7 @@ machine:
           permissions: 420
     install:
         disk: /dev/nvme0n1
-        image: factory.talos.dev/installer/c682c3b7e2747ecadb2b2f9eb73336e40373cfbe6f7ec588336ece6f3a1059cf:v1.13.8
+        image: factory.talos.dev/installer/c682c3b7e2747ecadb2b2f9eb73336e40373cfbe6f7ec588336ece6f3a1059cf:v1.13.7
         wipe: false
     kernel:
         modules:

--- a/cmd/homeops-cli/internal/templates/testdata/golden/talos/worker.yaml-192.168.122.11.yaml
+++ b/cmd/homeops-cli/internal/templates/testdata/golden/talos/worker.yaml-192.168.122.11.yaml
@@ -59,7 +59,7 @@ machine:
           permissions: 420
     install:
         disk: /dev/nvme0n1
-        image: factory.talos.dev/installer/c682c3b7e2747ecadb2b2f9eb73336e40373cfbe6f7ec588336ece6f3a1059cf:v1.13.8
+        image: factory.talos.dev/installer/c682c3b7e2747ecadb2b2f9eb73336e40373cfbe6f7ec588336ece6f3a1059cf:v1.13.7
         wipe: false
     kernel:
         modules:

--- a/cmd/homeops-cli/internal/templates/testdata/golden/talos/worker.yaml-192.168.122.12.yaml
+++ b/cmd/homeops-cli/internal/templates/testdata/golden/talos/worker.yaml-192.168.122.12.yaml
@@ -59,7 +59,7 @@ machine:
           permissions: 420
     install:
         disk: /dev/nvme0n1
-        image: factory.talos.dev/installer/c682c3b7e2747ecadb2b2f9eb73336e40373cfbe6f7ec588336ece6f3a1059cf:v1.13.8
+        image: factory.talos.dev/installer/c682c3b7e2747ecadb2b2f9eb73336e40373cfbe6f7ec588336ece6f3a1059cf:v1.13.7
         wipe: false
     kernel:
         modules:


### PR DESCRIPTION
Unblocks the `Go - Build / Lint / Test` job, which has been red on `main` and every Renovate branch since 2026-08-06 and is why bot PRs stopped auto-merging.

**Root cause:** Renovate's scope includes `testdata/`, so it rewrites version strings inside checked-in fixtures and goldens while the Go assertions paired with them stay stale.

- `TestExtractEtcdImageRefFromManifestFixture` — #1438 bumped the fixture to `3.7.1-0`; assertion still expected `3.7.0-0`. Now asserts on image shape, with a new `TestExtractEtcdImageRefSelectsEtcdContainer` covering container selection and the blank-image error path so coverage doesn't regress.
- `TestTalosRenderCharacterization` (`repo-mirror`, `no-config`) — #1465 bumped the installer tag in the goldens to `v1.13.8` while the test renders with `TALOS_VERSION` `v1.13.7`. Goldens regenerated to match.
- `**/testdata/**` added to renovate `ignorePaths` so this can't recur.

**Verification:** `go build ./...`, `go vet ./...`, `go test ./...` all clean locally.
